### PR TITLE
Feature: Table aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,24 @@ User::joinRelationship('posts', function ($join) {
 
 When using model scopes inside a join clause, you **can't** type hint the `$query` parameter in your scope. Also, keep in mind you are inside a join, so you are limited to use only conditions supported by joins.
 
+**Using aliases**
+
+Sometimes, you are going to need to use table aliases on your joins because you are joining the same table more than once. One option to accomplish this is to use the `joinRelationshipUsingAlias` method.
+
+```php
+Post::joinRelationshipUsingAlias('category.parent')->get();
+```
+
+Or, you can also call the `as` function inside the join callback.
+
+```php
+Post::joinRelationship('category.parent', [
+    'parent' => function ($join) {
+        $join->as('category_parent');
+    },
+])->get()
+```
+
 **Select * from table**
 
 When making joins, using `select * from ...` can be dangerous as fields with the same name between the parent and the joined tables could conflict. Thinking on that, if you call the `joinRelationship` method without previously selecting any specific columns, Eloquent Power Joins will automatically include that for you. For instance, take a look at the following examples:

--- a/src/Mixins/JoinRelationship.php
+++ b/src/Mixins/JoinRelationship.php
@@ -41,7 +41,6 @@ class JoinRelationship
     public function joinRelationship()
     {
         return function ($relationName, $callback = null, $joinType = 'join', $useAlias = false) {
-            $useAlias = $this->shouldUseAlias($useAlias);
             $joinType = JoinRelationship::$joinMethodsMap[$joinType] ?? $joinType;
 
             if (is_null($this->getSelect())) {
@@ -343,23 +342,13 @@ class JoinRelationship
         };
     }
 
-    /**
-     * Check if the current join should use aliases.
-     */
-    public function shouldUseAlias()
-    {
-        return function ($shouldUseAlias) {
-            return $shouldUseAlias;
-        };
-    }
-
     public function generateAliasForRelationship()
     {
         return function ($relation, $relationName) {
             if ($relation instanceof BelongsToMany || $relation instanceof HasManyThrough) {
                 return [
-                   md5($relationName.'table1'.time()),
-                   md5($relationName.'table2' . time()),
+                    md5($relationName.'table1'.time()),
+                    md5($relationName.'table2'.time()),
                 ];
             }
 
@@ -384,12 +373,8 @@ class JoinRelationship
     {
         return function () {
             JoinRelationship::$powerJoinAliasesCache = [];
+
             return $this;
         };
-    }
-
-    public static function getAliasFor($model = null, $default = null)
-    {
-        return JoinRelationship::$powerJoinAliasesCache[spl_object_id($model)] ?? $default;
     }
 }

--- a/src/Mixins/JoinRelationship.php
+++ b/src/Mixins/JoinRelationship.php
@@ -338,12 +338,12 @@ class JoinRelationship
         return function ($relation, $relationName) {
             if ($relation instanceof BelongsToMany || $relation instanceof HasManyThrough) {
                 return [
-                   md5($relationName . 'table1' . time()),
-                   md5($relationName . 'table2' . time())
+                   md5($relationName.'table1'.time()),
+                   md5($relationName.'table2' . time()),
                 ];
             }
 
-            return md5($relationName . time());
+            return md5($relationName.time());
         };
     }
 

--- a/src/Mixins/JoinRelationship.php
+++ b/src/Mixins/JoinRelationship.php
@@ -77,6 +77,26 @@ class JoinRelationship
         };
     }
 
+    /**
+     * Left join the relationship(s) using table aliases.
+     */
+    public function leftJoinRelationshipUsingAlias()
+    {
+        return function ($relationName, $callback = null) {
+            return $this->joinRelationship($relationName, $callback, 'leftJoin', true);
+        };
+    }
+
+    /**
+     * Right join the relationship(s) using table aliases.
+     */
+    public function rightJoinRelationshipUsingAlias()
+    {
+        return function ($relationName, $callback = null) {
+            return $this->joinRelationship($relationName, $callback, 'rightJoin', true);
+        };
+    }
+
     public function joinRelation()
     {
         return function ($relationName, $callback = null, $joinType = 'join') {
@@ -368,8 +388,8 @@ class JoinRelationship
         };
     }
 
-    public static function getAliasFor($relationName = null)
+    public static function getAliasFor($model = null, $default = null)
     {
-        return JoinRelationship::$powerJoinAliasesCache[$relationName] ?? null;
+        return JoinRelationship::$powerJoinAliasesCache[spl_object_id($model)] ?? $default;
     }
 }

--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -271,7 +271,7 @@ class RelationshipsExtraMethods
     public function getTableOrAliasForModel()
     {
         return function ($model, $default = null) {
-            return JoinRelationship::$powerJoinAliasesCache[spl_object_id($model)] ?? $default;
+            return JoinRelationship::getAliasFor($model, $default);
         };
     }
 }

--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -271,7 +271,7 @@ class RelationshipsExtraMethods
     public function getTableOrAliasForModel()
     {
         return function ($model, $default = null) {
-            return JoinRelationship::getAliasFor($model, $default);
+            return JoinRelationship::$powerJoinAliasesCache[spl_object_id($model)] ?? $default;
         };
     }
 }

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -73,6 +73,10 @@ class PowerJoinClause extends JoinClause
 
     protected function useTableAliasInConditions()
     {
+        if (! $this->alias) {
+            return $this;
+        }
+
         $this->wheres = collect($this->wheres)->filter(function ($where) {
             return in_array($where['type'] ?? '', ['Column']);
         })->map(function ($where) {
@@ -82,6 +86,8 @@ class PowerJoinClause extends JoinClause
 
             return $where;
         });
+
+        return $this;
     }
 
     public function __call($name, $arguments)

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -5,6 +5,7 @@ namespace KirschbaumDevelopment\EloquentJoins;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Str;
 
 class PowerJoinClause extends JoinClause
 {
@@ -73,16 +74,24 @@ class PowerJoinClause extends JoinClause
 
     protected function useTableAliasInConditions()
     {
-        if (! $this->alias) {
+        if (! $this->alias || ! $this->model) {
             return $this;
         }
 
         $this->wheres = collect($this->wheres)->filter(function ($where) {
             return in_array($where['type'] ?? '', ['Column']);
         })->map(function ($where) {
-            // dump($where, $this->table, $this->alias);
-            $where['first'] = str_replace($this->tableName, $this->alias, $where['first']);
-            $where['second'] = str_replace($this->tableName, $this->alias, $where['second']);
+            $key = $this->model->getKeyName();
+            $table = $this->tableName;
+
+            if (Str::contains($where['first'], $table) && Str::contains($where['second'], $table)) {
+                // if joining the same table, only replace the correct table.key pair
+                $where['first'] = str_replace($table.'.'.$key, $this->alias.'.'.$key, $where['first']);
+                $where['second'] = str_replace($table.'.'.$key, $this->alias.'.'.$key, $where['second']);
+            } else {
+                $where['first'] = str_replace($table, $this->alias, $where['first']);
+                $where['second'] = str_replace($table, $this->alias, $where['second']);
+            }
 
             return $where;
         });

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -14,6 +14,20 @@ class PowerJoinClause extends JoinClause
     public $model;
 
     /**
+     * Table name backup in case an alias is being used.
+     *
+     * @var string
+     */
+    public $tableName;
+
+    /**
+     * Alias name.
+     *
+     * @var string
+     */
+    public $alias;
+
+    /**
      * Create a new join clause instance.
      *
      * @param  \Illuminate\Database\Query\Builder  $parentQuery
@@ -27,11 +41,47 @@ class PowerJoinClause extends JoinClause
         parent::__construct($parentQuery, $type, $table);
 
         $this->model = $model;
+        $this->tableName = $table;
+    }
+
+    /**
+     * Add an alias to the table being joined.
+     *
+     * @return self
+     */
+    public function as(string $alias)
+    {
+        $this->alias = $alias;
+        $this->table = sprintf('%s as %s', $this->table, $alias);
+        $this->useTableAliasInConditions();
+
+        return $this;
+    }
+
+    public function on($first, $operator = null, $second = null, $boolean = 'and')
+    {
+        parent::on($first, $operator, $second, $boolean);
+        $this->useTableAliasInConditions();
+
+        return $this;
     }
 
     public function getModel()
     {
         return $this->model;
+    }
+
+    protected function useTableAliasInConditions()
+    {
+        $this->wheres = collect($this->wheres)->filter(function ($where) {
+            return in_array($where['type'] ?? '', ['Column']);
+        })->map(function ($where) {
+            // dump($where, $this->table, $this->alias);
+            $where['first'] = str_replace($this->tableName, $this->alias, $where['first']);
+            $where['second'] = str_replace($this->tableName, $this->alias, $where['second']);
+
+            return $where;
+        });
     }
 
     public function __call($name, $arguments)

--- a/tests/JoinRelationshipTest.php
+++ b/tests/JoinRelationshipTest.php
@@ -2,7 +2,6 @@
 
 namespace KirschbaumDevelopment\EloquentJoins\Tests;
 
-use KirschbaumDevelopment\EloquentJoins\Tests\Models\Category;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\Comment;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\Post;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\User;

--- a/tests/JoinRelationshipTest.php
+++ b/tests/JoinRelationshipTest.php
@@ -2,6 +2,7 @@
 
 namespace KirschbaumDevelopment\EloquentJoins\Tests;
 
+use KirschbaumDevelopment\EloquentJoins\Tests\Models\Category;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\Comment;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\Post;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\User;

--- a/tests/JoinRelationshipUsingAliasTest.php
+++ b/tests/JoinRelationshipUsingAliasTest.php
@@ -3,7 +3,9 @@
 namespace KirschbaumDevelopment\EloquentJoins\Tests;
 
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\Category;
+use KirschbaumDevelopment\EloquentJoins\Tests\Models\Comment;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\Post;
+use KirschbaumDevelopment\EloquentJoins\Tests\Models\User;
 
 class JoinRelationshipUsingAliasTest extends TestCase
 {
@@ -30,5 +32,43 @@ class JoinRelationshipUsingAliasTest extends TestCase
         $posts = Post::joinRelationshipUsingAlias('category.parent')->get();
 
         $this->assertCount(1, $posts);
+    }
+
+    /**
+     * @test
+     */
+    public function test_alias_for_has_many()
+    {
+        [$user1, $user2] = factory(User::class, 2)->create();
+        $post = factory(Post::class)->create(['user_id' => $user1->id]);
+
+        $users = User::joinRelationshipUsingAlias('posts')->get();
+        $query = User::joinRelationshipUsingAlias('posts')->toSql();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals($user1->id, $users->first()->id);
+        $this->assertStringContainsString('"posts" as', $query);
+        $this->assertStringNotContainsString('"posts"."user_id"', $query);
+    }
+
+    /**
+     * @test
+     */
+    public function test_alias_for_has_many_nested()
+    {
+        [$user1, $user2] = factory(User::class, 2)->create();
+        $post = factory(Post::class)->create(['user_id' => $user1->id]);
+        $comment = factory(Comment::class)->create(['post_id' => $post->id]);
+
+        $users = User::joinRelationshipUsingAlias('posts.comments')->get();
+        $query = User::joinRelationshipUsingAlias('posts.comments')->toSql();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals($user1->id, $users->first()->id);
+        $this->assertStringContainsString('"posts" as', $query);
+        $this->assertStringContainsString('"comments" as', $query);
+        $this->assertStringNotContainsString('"posts"."user_id"', $query);
+        $this->assertStringNotContainsString('"posts"."id"', $query);
+        $this->assertStringNotContainsString('"comments"."post_id"', $query);
     }
 }

--- a/tests/JoinRelationshipUsingAliasTest.php
+++ b/tests/JoinRelationshipUsingAliasTest.php
@@ -4,8 +4,10 @@ namespace KirschbaumDevelopment\EloquentJoins\Tests;
 
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\Category;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\Comment;
+use KirschbaumDevelopment\EloquentJoins\Tests\Models\Group;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\Post;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\User;
+use KirschbaumDevelopment\EloquentJoins\Tests\Models\UserProfile;
 
 class JoinRelationshipUsingAliasTest extends TestCase
 {
@@ -32,6 +34,32 @@ class JoinRelationshipUsingAliasTest extends TestCase
         $posts = Post::joinRelationshipUsingAlias('category.parent')->get();
 
         $this->assertCount(1, $posts);
+    }
+
+    /**
+     * @test
+     */
+    public function test_joining_the_same_table_twice_using_alias_with_join_as()
+    {
+        $category = factory(Category::class)->state('with:parent')->create();
+        $post = factory(Post::class)->create(['category_id' => $category->id]);
+
+        $posts = Post::joinRelationship('category.parent', [
+            'parent' => function ($join) {
+                $join->as('category_parent');
+            },
+        ])->get();
+        $query = Post::joinRelationship('category.parent', [
+            'parent' => function ($join) {
+                $join->as('category_parent');
+            },
+        ])->toSql();
+
+        $this->assertCount(1, $posts);
+        $this->assertStringContainsString(
+            'inner join "categories" as "category_parent" on "categories"."parent_id" = "category_parent"."id"',
+            $query
+        );
     }
 
     /**
@@ -69,6 +97,83 @@ class JoinRelationshipUsingAliasTest extends TestCase
         $this->assertStringContainsString('"comments" as', $query);
         $this->assertStringNotContainsString('"posts"."user_id"', $query);
         $this->assertStringNotContainsString('"posts"."id"', $query);
+        $this->assertStringNotContainsString('"comments"."post_id"', $query);
+    }
+
+    /**
+     * @test
+     */
+    public function test_alias_for_belongs_to_many()
+    {
+        [$user1, $user2] = factory(User::class, 2)->create();
+        $group = factory(Group::class)->create();
+        $user1->groups()->attach($group);
+
+        $users = User::query()->joinRelationshipUsingAlias('groups')->get();
+        $query = User::query()->joinRelationshipUsingAlias('groups')->toSql();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals($user1->id, $users->first()->id);
+        $this->assertStringContainsString('"group_members" as', $query);
+        $this->assertStringContainsString('"groups" as', $query);
+    }
+
+    /**
+     * @test
+     */
+    public function test_alias_for_belongs_to_many_nested()
+    {
+        [$user1, $user2] = factory(User::class, 2)->create();
+        $post = factory(Post::class)->create();
+        $group = factory(Group::class)->create();
+        $user1->groups()->attach($group);
+        $group->posts()->attach($post);
+
+        $users = User::query()->joinRelationshipUsingAlias('groups.posts')->get();
+        $query = User::query()->joinRelationshipUsingAlias('groups.posts')->toSql();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals($user1->id, $users->first()->id);
+        $this->assertStringContainsString('"group_members" as', $query);
+        $this->assertStringContainsString('"groups" as', $query);
+        $this->assertStringContainsString('"post_groups" as', $query);
+        $this->assertStringContainsString('"posts" as', $query);
+    }
+
+    /**
+     * @test
+     */
+    public function test_alias_for_has_one()
+    {
+        [$user1, $user2] = factory(User::class, 2)->create();
+        $profile = factory(UserProfile::class)->create(['user_id' => $user1->id]);
+
+        $users = User::joinRelationshipUsingAlias('profile')->get();
+        $query = User::joinRelationshipUsingAlias('profile')->toSql();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals($user1->id, $users->first()->id);
+        $this->assertStringContainsString('"user_profiles" as', $query);
+        $this->assertStringNotContainsString('"user_profiles"."user_id"', $query);
+    }
+
+    /**
+     * @test
+     */
+    public function test_alias_for_has_many_through()
+    {
+        [$user1, $user2] = factory(User::class, 2)->create();
+        $post = factory(Post::class)->create(['user_id' => $user1->id]);
+        $comment = factory(Comment::class)->create(['post_id' => $post->id]);
+
+        $users = User::joinRelationshipUsingAlias('commentsThroughPosts')->get();
+        $query = User::joinRelationshipUsingAlias('commentsThroughPosts')->toSql();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals($user1->id, $users->first()->id);
+        $this->assertStringContainsString('"posts" as', $query);
+        $this->assertStringNotContainsString('"posts"."user_id"', $query);
+        $this->assertStringContainsString('"comments" as', $query);
         $this->assertStringNotContainsString('"comments"."post_id"', $query);
     }
 }

--- a/tests/JoinRelationshipUsingAliasTest.php
+++ b/tests/JoinRelationshipUsingAliasTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace KirschbaumDevelopment\EloquentJoins\Tests;
+
+use KirschbaumDevelopment\EloquentJoins\Tests\Models\Category;
+use KirschbaumDevelopment\EloquentJoins\Tests\Models\Post;
+
+class JoinRelationshipUsingAliasTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function test_joining_using_auto_generated_alias()
+    {
+        $category = factory(Category::class)->state('with:parent')->create();
+        $post = factory(Post::class)->create(['category_id' => $category->id]);
+
+        $posts = Post::joinRelationshipUsingAlias('category')->get();
+
+        $this->assertCount(1, $posts);
+    }
+
+    /**
+     * @test
+     */
+    public function test_joining_the_same_table_twice_using_aliases()
+    {
+        $category = factory(Category::class)->state('with:parent')->create();
+        $post = factory(Post::class)->create(['category_id' => $category->id]);
+        $posts = Post::joinRelationshipUsingAlias('category.parent')->get();
+
+        $this->assertCount(1, $posts);
+    }
+}

--- a/tests/Models/Category.php
+++ b/tests/Models/Category.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace KirschbaumDevelopment\EloquentJoins\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Category extends Model
+{
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(Category::class, 'parent_id');
+    }
+}

--- a/tests/Models/Group.php
+++ b/tests/Models/Group.php
@@ -3,7 +3,12 @@
 namespace KirschbaumDevelopment\EloquentJoins\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Group extends Model
 {
+    public function posts(): BelongsToMany
+    {
+        return $this->belongsToMany(Post::class, 'post_groups', 'group_id', 'post_id');
+    }
 }

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -24,6 +24,11 @@ class Post extends Model
         return $this->morphMany(Image::class, 'imageable');
     }
 
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+
     public function scopePublished($query)
     {
         $query->where('posts.published', true);

--- a/tests/database/factories/CategoryFactory.php
+++ b/tests/database/factories/CategoryFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+use KirschbaumDevelopment\EloquentJoins\Tests\Models\Category;
+
+$factory->define(Category::class, function (Faker\Generator $faker) {
+    return [
+        'title' => $faker->words(3, true),
+    ];
+});
+
+$factory->state(Category::class, 'with:parent', [
+    'parent_id' => factory(Category::class),
+]);

--- a/tests/database/factories/PostFactory.php
+++ b/tests/database/factories/PostFactory.php
@@ -1,11 +1,13 @@
 <?php
 
+use KirschbaumDevelopment\EloquentJoins\Tests\Models\Category;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\Post;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\User;
 
 $factory->define(Post::class, function (Faker\Generator $faker) {
     return [
         'user_id' => factory(User::class),
+        'category_id' => factory(Category::class),
         'title' => $faker->words(3, true),
     ];
 });

--- a/tests/database/migrations/2020_03_16_000000_create_tables.php
+++ b/tests/database/migrations/2020_03_16_000000_create_tables.php
@@ -47,6 +47,11 @@ class CreateTables extends Migration
             $table->timestamps();
         });
 
+        Schema::create('post_groups', function (Blueprint $table) {
+            $table->unsignedInteger('group_id');
+            $table->unsignedInteger('post_id');
+        });
+
         Schema::create('categories', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('parent_id')->nullable()->default(null);

--- a/tests/database/migrations/2020_03_16_000000_create_tables.php
+++ b/tests/database/migrations/2020_03_16_000000_create_tables.php
@@ -41,8 +41,16 @@ class CreateTables extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('user_id');
+            $table->unsignedInteger('category_id');
             $table->string('title');
             $table->boolean('published')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('categories', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('parent_id')->nullable()->default(null);
+            $table->string('title');
             $table->timestamps();
         });
 


### PR DESCRIPTION
This PR implements the ability to use table aliases in the joins being made. It can be used in two ways.

### Automatic

By calling the `joinRelationshipUsingAlias` method.

```php
Post::joinRelationshipUsingAlias('category.parent')->get();
```

This generates the following query:

```sql
SELECT "posts".* FROM "posts"
    INNER JOIN "categories" AS "40071de3fbcf4e9399e166813abb7718" ON "posts"."category_id" = "40071de3fbcf4e9399e166813abb7718"."id"
    INNER JOIN "categories" AS "ccecda2ab44b29ec904f7bdea7e5aa2e" ON "40071de3fbcf4e9399e166813abb7718"."parent_id" = "ccecda2ab44b29ec904f7bdea7e5aa2e"."id"
```

### By calling ->alias

You can also manually specify the table alias you want to use in the join callbacks.

```php
Post::joinRelationship('category.parent', [
    'parent' => function ($join) {
        $join->as('category_parent');
    },
])->get();
```

This generates the following query:

```sql
SELECT "posts".* FROM "posts"
    INNER JOIN "categories" ON "posts"."category_id" = "categories"."id"
    INNER JOIN "categories" AS "category_parent" ON "categories"."parent_id" = "category_parent"."id"
```

This PR closes #9.