### PR TITLE
[2.0] Applying extra relationship conditions in joins

### DIFF
--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -88,6 +88,14 @@ class RelationshipsExtraMethods
                     );
                 }
 
+                foreach ($this->getQuery()->getQuery()->wheres as $condition) {
+                    if ($condition['type'] === 'Null' || $condition['type'] === 'NotNull') {
+                        continue;
+                    }
+
+                    $join->where($condition['column'], $condition['operator'], $condition['value']);
+                }
+
                 if ($callback && is_callable($callback)) {
                     $callback($join);
                 }

--- a/tests/JoinRelationshipTest.php
+++ b/tests/JoinRelationshipTest.php
@@ -2,6 +2,7 @@
 
 namespace KirschbaumDevelopment\EloquentJoins\Tests;
 
+use KirschbaumDevelopment\EloquentJoins\Tests\Models\Category;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\Comment;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\Post;
 use KirschbaumDevelopment\EloquentJoins\Tests\Models\User;
@@ -332,6 +333,24 @@ class JoinRelationshipTest extends TestCase
 
         $this->assertStringContainsString(
             'inner join "comments" on "comments"."post_id" = "posts"."id"',
+            $query
+        );
+    }
+
+    /** @test */
+    public function test_join_has_many_relationship_with_additional_conditions()
+    {
+        [$category1, $category2] = factory(Category::class, 2)->create();
+        factory(Post::class)->states('published')->create(['category_id' => $category1->id]);
+
+        $query = Category::joinRelationship('publishedPosts')->toSql();
+        $categories = Category::joinRelationship('publishedPosts')->get();
+
+        $this->assertCount(1, $categories);
+        $this->assertEquals($category1->id, $categories->first()->id);
+
+        $this->assertStringContainsString(
+            'inner join "posts" on "posts"."category_id" = "categories"."id" and "posts"."published" = ?',
             $query
         );
     }

--- a/tests/Models/Category.php
+++ b/tests/Models/Category.php
@@ -4,11 +4,23 @@ namespace KirschbaumDevelopment\EloquentJoins\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use KirschbaumDevelopment\EloquentJoins\Tests\Models\Post;
 
 class Category extends Model
 {
     public function parent(): BelongsTo
     {
         return $this->belongsTo(Category::class, 'parent_id');
+    }
+
+    public function posts(): HasMany
+    {
+        return $this->hasMany(Post::class);
+    }
+
+    public function publishedPosts(): HasMany
+    {
+        return $this->hasMany(Post::class)->published();
     }
 }


### PR DESCRIPTION
The idea is to apply any extra conditions in your relationships automatically in joins, i.e:

```php
class Category extends Model
{
    public function publishedPosts()
    {
        return $this->hasMany(Post::class)->published();
    }
}

class Post extends Model
{
    public function scopePublished($query)
    {
        $query->where('posts.published', true);
    }
}
```

So, if you run the `joinRelationship` method, the following should happen:

```php
$categories = Category::joinRelationship('publishedPosts')->toSql();
```

```sql
select "categories".* 
from "categories" 
inner join "posts" on "posts"."category_id" = "categories"."id" 
    and "posts"."published" = ?
```