### PR TITLE
Fixed the ability to pass nested closures in join callbacks when using aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `eloquent-power-joins` will be documented in this file.
 
+## 2.2.2 - 2020-10
+- Fixed the ability to pass nested closures in join callbacks when using aliases;
+
 ## 2.2.1 - 2020-10
 - Fixed nested conditions in relationship definitions;
 

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -115,7 +115,7 @@ class PowerJoinClause extends JoinClause
 
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
-        if ($this->alias && Str::contains($column, $this->tableName)) {
+        if ($this->alias && is_string($column) && Str::contains($column, $this->tableName)) {
             $column = str_replace("{$this->tableName}.", "{$this->alias}.", $column);
         }
 


### PR DESCRIPTION
Issue #31 