### PR TITLE
Make sure join cache is cleared between queries

### DIFF
--- a/src/PowerJoins.php
+++ b/src/PowerJoins.php
@@ -368,4 +368,9 @@ trait PowerJoins
 
         return $this;
     }
+
+    public function __destruct()
+    {
+        PowerJoins::$joinRelationshipCache = [];
+    }
 }

--- a/tests/JoinRelationshipTest.php
+++ b/tests/JoinRelationshipTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirschbaum\PowerJoins\Tests;
 
+use Kirschbaum\PowerJoins\PowerJoins;
 use Kirschbaum\PowerJoins\Tests\Models\Post;
 use Kirschbaum\PowerJoins\Tests\Models\User;
 use Kirschbaum\PowerJoins\Tests\Models\Image;
@@ -419,5 +420,15 @@ class JoinRelationshipTest extends TestCase
             'inner join "categories" as "category_alias" on "posts"."category_id" = "category_alias"."id" and ("category_alias"."parent_id" is null or "category_alias"."parent_id" = ?)',
             $sql
         );
+    }
+
+    /** @test */
+    public function test_join_cache_is_cleared_between_queries()
+    {
+        $query = User::query()->joinRelationship('posts')->toSql();
+        $this->assertEmpty(PowerJoins::$joinRelationshipCache, 'Join Relationship Cache not cleared after query');
+
+        $query = User::query()->joinRelationship('posts')->toSql();
+        $this->assertEmpty(PowerJoins::$joinRelationshipCache, 'Join Relationship Cache not cleared after query');
     }
 }


### PR DESCRIPTION
This is related to issue #32 

Since the join cache was never cleared old spl_object_id()'s were being used at random during the script execution causing the query to not perform any joins.
