### PR TITLE
Add ability to chain scopes

### DIFF
--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -167,7 +167,7 @@ class PowerJoinClause extends JoinClause
         $scope = 'scope' . ucfirst($name);
 
         if (method_exists($this->getModel(), $scope)) {
-            $this->getModel()->{$scope}($this, ...$arguments);
+            return $this->getModel()->{$scope}($this, ...$arguments);
         } else {
             throw new InvalidArgumentException(sprintf('Method %s does not exist in PowerJoinClause class', $name));
         }


### PR DESCRIPTION
Currently, using the scopes, you can't chain more scopes like so:
```php
User::joinRelationship('bookableResources', fn ($q) => $q->verified()->banned())
```

Using the code above, `banned()` fails because the return for `verified()` is `void`.