### PR TITLE
added check to see if the used alias should be custom or user provided

### DIFF
--- a/src/PowerJoins.php
+++ b/src/PowerJoins.php
@@ -40,7 +40,7 @@ trait PowerJoins
     public function scopeJoinRelationship(Builder $query, $relationName, $callback = null, $joinType = 'join', $useAlias = false, bool $disableExtraConditions = false): void
     {
         $joinType = PowerJoins::$joinMethodsMap[$joinType] ?? $joinType;
-        $useAlias = $useAlias && !is_string($callback);
+        $useAlias = is_string($callback) ? false : $useAlias;
         $callback = $this->formatJoinCallback($relationName, $callback);
 
         if (is_null($query->getSelect())) {

--- a/src/PowerJoins.php
+++ b/src/PowerJoins.php
@@ -40,6 +40,7 @@ trait PowerJoins
     public function scopeJoinRelationship(Builder $query, $relationName, $callback = null, $joinType = 'join', $useAlias = false, bool $disableExtraConditions = false): void
     {
         $joinType = PowerJoins::$joinMethodsMap[$joinType] ?? $joinType;
+        $useAlias = $useAlias && !is_string($callback);
         $callback = $this->formatJoinCallback($relationName, $callback);
 
         if (is_null($query->getSelect())) {

--- a/tests/JoinRelationshipUsingAliasTest.php
+++ b/tests/JoinRelationshipUsingAliasTest.php
@@ -27,6 +27,19 @@ class JoinRelationshipUsingAliasTest extends TestCase
     /**
      * @test
      */
+    public function test_joining_using_provided_alias()
+    {
+        $category = factory(Category::class)->state('with:parent')->create();
+        $post = factory(Post::class)->create(['category_id' => $category->id]);
+
+        $sql = Post::joinRelationshipUsingAlias('category', 'my_alias')->toSql();
+
+        $this->assertStringContainsString('my_alias', $sql);
+    }
+
+    /**
+     * @test
+     */
     public function test_joining_the_same_table_twice_using_aliases()
     {
         $category = factory(Category::class)->state('with:parent')->create();


### PR DESCRIPTION
Hi,

Thanks for your awesome package. 

As stated in #74  if you provide a custom alias as a string it gets ignored and an autogenerated alias is used instead.
In this PR I have created a possible fix and added a test.

Cheers

fixes #74 