### PR TITLE
powerJoinWhereHas now calls the callback function

### DIFF
--- a/src/PowerJoins.php
+++ b/src/PowerJoins.php
@@ -284,7 +284,7 @@ trait PowerJoins
     /**
      * Same as Laravel 'has`, but using joins instead of where exists.
      */
-    public function scopePowerJoinHas(Builder $query, $relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null): void
+    public function scopePowerJoinHas(Builder $query, $relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null, $assertExistence = false): void
     {
         if (is_null($query->getSelect())) {
             $query->select(sprintf('%s.*', $query->getModel()->getTable()));
@@ -304,7 +304,7 @@ trait PowerJoins
             $relation = $query->getRelationWithoutConstraintsProxy($relation);
         }
 
-        $relation->performJoinForEloquentPowerJoins($query, 'leftPowerJoin', $callback);
+        $relation->performJoinForEloquentPowerJoins($query, 'leftPowerJoin', $callback, null, $assertExistence);
         $relation->performHavingForEloquentPowerJoins($query, $operator, $count);
     }
 
@@ -339,7 +339,7 @@ trait PowerJoins
 
     public function scopePowerJoinWhereHas(Builder $query, $relation, Closure $callback = null, $operator = '>=', $count = 1): void
     {
-        $query->powerJoinHas($relation, $operator, $count, 'and', $callback);
+        $query->powerJoinHas($relation, $operator, $count, 'and', $callback, true);
     }
 
     /**

--- a/tests/PowerJoinHasTest.php
+++ b/tests/PowerJoinHasTest.php
@@ -113,6 +113,31 @@ class PowerJoinHasTest extends TestCase
     }
 
     /** @test */
+    public function test_where_has_with_joins_on_has_many_through_relationship()
+    {
+        [$user1, $user2, $user3] = factory(User::class)->times(3)->create();
+        $post1 = factory(Post::class)->create(['user_id' => $user1->id]);
+        $post2 = factory(Post::class)->create(['user_id' => $user2->id]);
+        $post3 = factory(Post::class)->create(['user_id' => $user3->id]);
+        $commentsPost1 = factory(Comment::class)->times(2)->create(['post_id' => $post1->id]);
+        $commentsPost2 = factory(Comment::class)->times(2)->create(['post_id' => $post2->id]);
+        $commentsPost3 = factory(Comment::class)->times(1)->create(['post_id' => $post3->id]);
+        $commentsPost1[0]->body = 'a';
+        $commentsPost1[1]->body = 'a';
+        $commentsPost1[0]->save();
+        $commentsPost1[1]->save();
+        $commentsPost2[0]->body = 'a';
+        $commentsPost2[0]->save();
+
+        $closure = function($query) {
+            $query->where('body', 'a');
+        };
+
+        $this->assertCount(2, User::whereHas('commentsThroughPosts', $closure)->get());
+        $this->assertCount(2, User::powerJoinWhereHas('commentsThroughPosts', $closure)->get());
+    }
+
+    /** @test */
     public function test_doesnt_have()
     {
         [$user1, $user2] = factory(User::class)->times(2)->create();


### PR DESCRIPTION
I have added an assert existence parameter for `performJoinForEloquentPowerJoinsForHasManyThrough` so additional conditions from callback function will be applied. Fixes #55.