### PR TITLE
Run CI tests also on PHP 8.1 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [7.4, 8.0]
+                php: [7.4, 8.0, 8.1]
                 laravel: [7.*, 8.*, 9.*]
                 include:
                     -   laravel: 9.*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
                 exclude:
                     -   laravel: 9.*
                         php: 7.4
+                    -   laravel: 7.*
+                        php: 8.1
 
         name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 


### PR DESCRIPTION
Laravel 7 does not support PHP 8.1. I have excluded it from the tests. 
It still tests Laravel 8 and 9 in combination with PHP 8.1