### PR TITLE
Potential Fix: Using `joinRelationship` on the same base relationship(s)

### DIFF
--- a/src/PowerJoins.php
+++ b/src/PowerJoins.php
@@ -56,7 +56,7 @@ trait PowerJoins
 
         $relation = $query->getModel()->{$relationName}();
         $relationQuery = $relation->getQuery();
-        $alias = $this->getAliasName($useAlias, $relation, $relationName, $callback);
+        $alias = $this->getAliasName($useAlias, $relation, $relationName, $relationQuery->getModel()->getTable(), $callback);
         $aliasString = is_array($alias) ? implode('.', $alias) : $alias;
 
         $relationJoinCache = $alias
@@ -64,6 +64,7 @@ trait PowerJoins
             : "{$relationQuery->getModel()->getTable()}.{$relationName}";
 
         if ($this->relationshipAlreadyJoined($relationJoinCache)) {
+            // dump($relationJoinCache, $relationName, $aliasString);
             return;
         }
 
@@ -132,22 +133,33 @@ trait PowerJoins
         /** @var \Illuminate\Database\Eloquent\Relations\Relation */
         $latestRelation = null;
 
-        foreach ($relations as $index => $relationName) {
+        foreach ($relations as $relationName) {
             $currentModel = $latestRelation ? $latestRelation->getModel() : $query->getModel();
             $relation = $currentModel->{$relationName}();
-            $alias = $useAlias ? $this->generateAliasForRelationship($relation, $relationName) : null;
             $relationCallback = null;
-            $relationJoinCache = $index === 0
-                ? "{$relation->getQuery()->getModel()->getTable()}.{$index}.{$relationName}"
-                : "{$relation->getQuery()->getModel()->getTable()}.{$latestRelation->getModel()->getTable()}.{$relationName}";
+
+            if ($callback && is_array($callback) && isset($callback[$relationName])) {
+                $relationCallback = $callback[$relationName];
+            }
+
+            $alias = $this->getAliasName($useAlias, $relation, $relationName, $relation->getQuery()->getModel()->getTable(), $callback);
+            $alias = $useAlias ? $this->generateAliasForRelationship($relation, $relationName) : null;
+            $aliasString = is_array($alias) ? implode('.', $alias) : $alias;
+
+            if ($alias) {
+                $relationJoinCache = $latestRelation
+                    ? "{$aliasString}.{$relation->getQuery()->getModel()->getTable()}.{$latestRelation->getModel()->getTable()}.{$relationName}"
+                    : "{$aliasString}.{$relation->getQuery()->getModel()->getTable()}.{$relationName}";
+            } else {
+                $relationJoinCache = $latestRelation
+                    ? "{$relation->getQuery()->getModel()->getTable()}.{$latestRelation->getModel()->getTable()}.{$relationName}"
+                    : "{$relation->getQuery()->getModel()->getTable()}.{$relationName}";
+            }
 
             if ($useAlias) {
                 $this->cachePowerJoinAlias($relation->getModel(), $alias);
             }
 
-            if ($callback && is_array($callback) && isset($callback[$relationName])) {
-                $relationCallback = $callback[$relationName];
-            }
 
             if ($this->relationshipAlreadyJoined($relationJoinCache)) {
                 $latestRelation = $relation;
@@ -351,18 +363,7 @@ trait PowerJoins
      */
     public function relationshipAlreadyJoined($relation)
     {
-        $objectId = spl_object_id($this);
-        $beforeLast = Str::beforeLast(str_replace('.0', '', $relation), '.');
-
-        if (isset($this->joinRelationshipCache[$objectId])) {
-            foreach (array_keys($this->joinRelationshipCache[$objectId]) as $relationshipKey) {
-                if (Str::contains($relationshipKey, $beforeLast)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return isset($this->joinRelationshipCache[spl_object_id($this)][$relation]);
     }
 
     /**
@@ -423,13 +424,24 @@ trait PowerJoins
 
     /**
      * Get the join alias name from all the different options.
+     *
+     * @return string|null
      */
-    protected function getAliasName($useAlias, $relation, $relationName, $callback)
+    protected function getAliasName($useAlias, $relation, $relationName, $tableName, $callback)
     {
         if ($callback) {
             if (is_callable($callback)) {
                 $fakeJoinCallback = new FakeJoinCallback();
                 $callback($fakeJoinCallback);
+
+                if ($fakeJoinCallback->getAlias()) {
+                    return $fakeJoinCallback->getAlias();
+                }
+            }
+
+            if (is_array($callback) && isset($callback[$tableName])) {
+                $fakeJoinCallback = new FakeJoinCallback();
+                $callback[$tableName]($fakeJoinCallback);
 
                 if ($fakeJoinCallback->getAlias()) {
                     return $fakeJoinCallback->getAlias();

--- a/src/PowerJoins.php
+++ b/src/PowerJoins.php
@@ -352,7 +352,7 @@ trait PowerJoins
     public function relationshipAlreadyJoined($relation)
     {
         $objectId = spl_object_id($this);
-        $beforeLast = Str::beforeLast(Str::replace('.0', '', $relation), '.');
+        $beforeLast = Str::beforeLast(str_replace('.0', '', $relation), '.');
 
         if (isset($this->joinRelationshipCache[$objectId])) {
             foreach (array_keys($this->joinRelationshipCache[$objectId]) as $relationshipKey) {

--- a/src/PowerJoins.php
+++ b/src/PowerJoins.php
@@ -351,7 +351,18 @@ trait PowerJoins
      */
     public function relationshipAlreadyJoined($relation)
     {
-        return isset($this->joinRelationshipCache[spl_object_id($this)][$relation]);
+        $objectId = spl_object_id($this);
+        $beforeLast = Str::beforeLast(Str::replace('.0', '', $relation), '.');
+
+        if (isset($this->joinRelationshipCache[$objectId])) {
+            foreach (array_keys($this->joinRelationshipCache[$objectId]) as $relationshipKey) {
+                if (Str::contains($relationshipKey, $beforeLast)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/JoinRelationshipTest.php
+++ b/tests/JoinRelationshipTest.php
@@ -274,12 +274,17 @@ class JoinRelationshipTest extends TestCase
     {
         $query = User::query()
             ->select('users.*')
+            ->joinRelationship('posts')
             ->joinRelationship('posts.comments')
             ->joinRelationship('posts.images')
             ->toSql();
 
         // making sure it doesn't throw any errors
-        User::query()->select('users.*')->joinRelationship('posts.comments')->joinRelationship('posts.images')->get();
+        User::query()->select('users.*')
+            ->joinRelationship('posts')
+            ->joinRelationship('posts.comments')
+            ->joinRelationship('posts.images')
+            ->get();
 
         $this->assertStringContainsString(
             'inner join "posts" on "posts"."user_id" = "users"."id"',
@@ -575,6 +580,9 @@ class JoinRelationshipTest extends TestCase
                 'parent' => fn ($join) => $join->as('parent_alias'),
             ])
             ->get();
+
+        // if it does not throw any exceptions, we are good
+        $this->assertTrue(true);
     }
 
     /** @test */


### PR DESCRIPTION
This is an attempt at fixing Issue #90. I'm not 100% sure this is the cleanest way to do this but it's passing automated tests and I set up the following example locally and it seems like the SQL is correct.

```php
Route::get('/', function () {
    $query = Post::query()->joinRelationship('author');
    $query->joinRelationship('author.department');
    $query->joinRelationship('author.department.organization');

    return $query->dd();
});
```

```sql
SELECT
    `posts`.*
FROM
    `posts`
    INNER JOIN `users` ON `posts`.`author_id` = `users`.`id`
    INNER JOIN `departments` ON `users`.`department_id` = `departments`.`id`
    INNER JOIN `organizations` ON `departments`.`organization_id` = `organizations`.`id`
```