### PR TITLE
Join type in nested sub-relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ User::joinRelationship('posts.comments', [
     },
     'comments' => function ($join) {
         $join->where('comments.approved', true);
+        $join->left(); // you may also indicate join type using methods ->left()/->inner()
     }
 ]);
 ```

--- a/src/FakeJoinCallback.php
+++ b/src/FakeJoinCallback.php
@@ -5,16 +5,28 @@ namespace Kirschbaum\PowerJoins;
 class FakeJoinCallback
 {
     protected $alias = null;
+    protected $joinType = null;
 
     public function getAlias(): ?string
     {
         return $this->alias;
     }
 
+    public function getJoinType(): ?string
+    {
+        return $this->joinType;
+    }
+
     public function __call($name, $arguments)
     {
         if ($name === 'as') {
             $this->alias = $arguments[0];
+        }elseif ($name === 'joinType') {
+            $this->joinType = $arguments[0];
+        }elseif ($name === 'left') {
+            $this->joinType = 'leftPowerJoin';
+        }elseif ($name === 'inner') {
+            $this->joinType = 'powerJoin';
         }
 
         return $this;


### PR DESCRIPTION
Possibility to indicate join type for each relation in joinRelationship callbacks:

User::joinRelationship('posts.comments', [
    'posts' => function ($join) {
        $join->where('posts.published', true);
    },
    'comments' => function ($join) {
        $join->where('comments.approved', true);
        $join->left(); // you may also use $join->inner() or directly $join->joinType('leftPowerJoin')
    }
]);

Probable not the most effective way, but the least intrusive.