### PR TITLE
Allow Macro calls on JoinClause

### DIFF
--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -189,7 +189,10 @@ class PowerJoinClause extends JoinClause
         if (method_exists($this->getModel(), $scope)) {
             return $this->getModel()->{$scope}($this, ...$arguments);
         } else {
-            throw new InvalidArgumentException(sprintf('Method %s does not exist in PowerJoinClause class', $name));
+            if (static::hasMacro($method)) {
+                return $this->macroCall($name, $arguments);
+            }
+            else throw new InvalidArgumentException(sprintf('Method %s does not exist in PowerJoinClause class', $name));
         }
     }
 }

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -189,7 +189,7 @@ class PowerJoinClause extends JoinClause
         if (method_exists($this->getModel(), $scope)) {
             return $this->getModel()->{$scope}($this, ...$arguments);
         } else {
-            if (static::hasMacro($method)) {
+            if (static::hasMacro($name)) {
                 return $this->macroCall($name, $arguments);
             }
             else throw new InvalidArgumentException(sprintf('Method %s does not exist in PowerJoinClause class', $name));

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -191,8 +191,9 @@ class PowerJoinClause extends JoinClause
         } else {
             if (static::hasMacro($name)) {
                 return $this->macroCall($name, $arguments);
+            } else {
+                throw new InvalidArgumentException(sprintf('Method %s does not exist in PowerJoinClause class', $name));
             }
-            else throw new InvalidArgumentException(sprintf('Method %s does not exist in PowerJoinClause class', $name));
         }
     }
 }


### PR DESCRIPTION
Hello,

Thank you for this package it's really nice to be able to reuse already defined relations like this.

While using your package i found out that it isn't possible to call QueryBuilder macros on JoinClause.
I like to be able to extend builders functionalities this way so i was wondering if you would consider allowing the call to be passed to the underlying builder.

Thanks for your time.