### PR TITLE
Encapsultate nested conditions inside a where statement

### DIFF
--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -348,10 +348,12 @@ class RelationshipsExtraMethods
     public function applyNestedCondition()
     {
         return function ($join, $condition) {
-            foreach ($condition['query']->wheres as $condition) {
-                $method = "apply{$condition['type']}Condition";
-                $this->$method($join, $condition);
-            }
+            $join->where(function($q) use($condition){
+                foreach ($condition['query']->wheres as $condition) {
+                    $method = "apply{$condition['type']}Condition";
+                    $this->$method($q, $condition);
+                }
+            });
         };
     }
 

--- a/tests/JoinRelationshipExtraConditionsTest.php
+++ b/tests/JoinRelationshipExtraConditionsTest.php
@@ -187,11 +187,11 @@ class JoinRelationshipExtraConditionsTest extends TestCase
     /** @test */
     public function test_extra_conditions_with_closure()
     {
-        $query = User::joinRelationship('publishedPosts')->toSql();
-        User::joinRelationship('publishedPosts')->get();
+        $query = User::joinRelationship('publishedOrReviewedPosts')->toSql();
+        User::joinRelationship('publishedOrReviewedPosts')->get();
 
         $this->assertStringContainsString(
-            'inner join "posts" on "posts"."user_id" = "users"."id" and ("published" = ?)',
+            'inner join "posts" on "posts"."user_id" = "users"."id" and ("published" = ? or "reviewed" = ?)',
             $query
         );
     }

--- a/tests/JoinRelationshipExtraConditionsTest.php
+++ b/tests/JoinRelationshipExtraConditionsTest.php
@@ -191,7 +191,7 @@ class JoinRelationshipExtraConditionsTest extends TestCase
         User::joinRelationship('publishedPosts')->get();
 
         $this->assertStringContainsString(
-            'inner join "posts" on "posts"."user_id" = "users"."id" and "published" = ?',
+            'inner join "posts" on "posts"."user_id" = "users"."id" and ("published" = ?)',
             $query
         );
     }

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -45,6 +45,14 @@ class User extends Model
         });
     }
 
+    public function publishedOrReviewedPosts(): HasMany
+    {
+        return $this->hasMany(Post::class)->where(function($query){
+           $query->where('published', true);
+           $query->orWhere('reviewed', true);
+        });
+    }
+
     public function comments(): HasMany
     {
         return $this->hasMany(Comment::class);

--- a/tests/database/factories/PostFactory.php
+++ b/tests/database/factories/PostFactory.php
@@ -12,5 +12,6 @@ $factory->define(Post::class, function (Faker\Generator $faker) {
     ];
 });
 
+$factory->state(Post::class, 'reviewed', ['reviewed' => true]);
 $factory->state(Post::class, 'published', ['published' => true]);
 $factory->state(Post::class, 'unpublished', ['published' => false]);

--- a/tests/database/migrations/2020_03_16_000000_create_tables.php
+++ b/tests/database/migrations/2020_03_16_000000_create_tables.php
@@ -50,6 +50,7 @@ class CreateTables extends Migration
             $table->unsignedInteger('user_id');
             $table->unsignedInteger('category_id');
             $table->string('title');
+            $table->boolean('reviewed')->default(true);
             $table->boolean('published')->default(true);
             $table->timestamps();
         });


### PR DESCRIPTION
When a relationship has a nested condition that contains a `WHERE ... OR ...` statement, this condition was not encapsulated inside parenthesis, unlike the "actual" relationship.

#### Example

```php
public function publishedOrReviewedPosts(): HasMany
{
    return $this->hasMany(Post::class)->where(function($q){
       $q->where('published', true);
       $q->orWhere('reviewed', true);
    });
}
```

Gave the following query after the relationship was joined : 

```php
$query = User::joinRelationship('publishedOrReviewedPosts')->toSql();

dd($query); // [...] inner join "posts" on "posts"."user_id" = "users"."id" and "published" = ? or "reviewed" = ? [...]
```

This was leading to unexpected results, since the correct behavior was to put `"published" = ? or "reviewed" = ?` inside parenthesis.

This PR fixes this issue.

I also updated the `test_extra_conditions_with_closure` so it gives a better "nested condition" example (this type of condition rarely come only with one _where_ statement) .