### PR TITLE
Update PowerJoinClause.php

### DIFF
--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -117,8 +117,8 @@ class PowerJoinClause extends JoinClause
                 $where['first'] = str_replace($table . '.' . $key, $this->alias . '.' . $key, $where['first']);
                 $where['second'] = str_replace($table . '.' . $key, $this->alias . '.' . $key, $where['second']);
             } else {
-                $where['first'] = str_replace($table, $this->alias, $where['first']);
-                $where['second'] = str_replace($table, $this->alias, $where['second']);
+                $where['first'] = str_replace($table . '.', $this->alias . '.', $where['first']);
+                $where['second'] = str_replace($table . '.', $this->alias . '.', $where['second']);
             }
 
             return $where;


### PR DESCRIPTION
Just added a dot in the str_remplace. So if you have a table shop and the primary key is shop_id it doesnt fail the join, just change the table, not the primary

$where['first'] = str_replace($table . '.', $this->alias . '.', $where['first']);