### PR TITLE
Fix when using alias in a 3 level relationship

### DIFF
--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -58,6 +58,10 @@ class PowerJoinClause extends JoinClause
     {
         $this->alias = $alias;
         $this->joinedTableAlias = $joinedTableAlias;
+        $cut = strpos($this->table," as ");
+        if ($cut !== false) {
+            $this->table = substr($this->table, 0, $cut);
+        }
         $this->table = sprintf('%s as %s', $this->table, $alias);
         $this->useTableAliasInConditions();
 
@@ -86,7 +90,7 @@ class PowerJoinClause extends JoinClause
      */
     public function withGlobalScopes(): self
     {
-        if (! $this->model) {
+        if (!$this->model) {
             return $this;
         }
 
@@ -102,7 +106,7 @@ class PowerJoinClause extends JoinClause
      */
     protected function useTableAliasInConditions(): self
     {
-        if (! $this->alias || ! $this->model) {
+        if (!$this->alias || !$this->model) {
             return $this;
         }
 
@@ -114,11 +118,11 @@ class PowerJoinClause extends JoinClause
 
             if (Str::contains($where['first'], $table) && Str::contains($where['second'], $table)) {
                 // if joining the same table, only replace the correct table.key pair
-                $where['first'] = str_replace($table . '.' . $key, $this->alias . '.' . $key, $where['first']);
-                $where['second'] = str_replace($table . '.' . $key, $this->alias . '.' . $key, $where['second']);
+                $where['first'] = preg_replace('/^' . $table . '.' . $key . '/', $this->alias . '.' . $key, $where['first']);
+                $where['second'] = preg_replace('/^' . $table . '.' . $key . '/', $this->alias . '.' . $key, $where['second']);
             } else {
-                $where['first'] = str_replace($table . '.', $this->alias . '.', $where['first']);
-                $where['second'] = str_replace($table . '.', $this->alias . '.', $where['second']);
+                $where['first'] = preg_replace('/^' . $table . '.' . '/', $this->alias . '.', $where['first']);
+                $where['second'] = preg_replace('/^' . $table . '.' . '/', $this->alias . '.', $where['second']);
             }
 
             return $where;
@@ -145,7 +149,7 @@ class PowerJoinClause extends JoinClause
     {
         if ($this->alias && is_string($column) && Str::contains($column, $this->tableName)) {
             $column = str_replace("{$this->tableName}.", "{$this->alias}.", $column);
-        } elseif ($this->alias && ! is_callable($column)) {
+        } elseif ($this->alias && !is_callable($column)) {
             $column = $this->alias . '.' . $column;
         }
 
@@ -163,7 +167,7 @@ class PowerJoinClause extends JoinClause
      */
     public function withTrashed(): self
     {
-        if (! in_array(SoftDeletes::class, class_uses_recursive($this->getModel()))) {
+        if (!in_array(SoftDeletes::class, class_uses_recursive($this->getModel()))) {
             return $this;
         }
 
@@ -183,7 +187,7 @@ class PowerJoinClause extends JoinClause
      */
     public function onlyTrashed(): self
     {
-        if (! in_array(SoftDeletes::class, class_uses_recursive($this->getModel()))) {
+        if (!in_array(SoftDeletes::class, class_uses_recursive($this->getModel()))) {
             return $this;
         }
 

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -117,8 +117,8 @@ class PowerJoinClause extends JoinClause
                 $where['first'] = str_replace($table . '.' . $key, $this->alias . '.' . $key, $where['first']);
                 $where['second'] = str_replace($table . '.' . $key, $this->alias . '.' . $key, $where['second']);
             } else {
-                $where['first'] = str_replace($table, $this->alias, $where['first']);
-                $where['second'] = str_replace($table, $this->alias, $where['second']);
+                $where['first'] = str_replace($table . '.', $this->alias . '.', $where['first']);
+                $where['second'] = str_replace($table . '.', $this->alias . '.', $where['second']);
             }
 
             return $where;

--- a/src/PowerJoins.php
+++ b/src/PowerJoins.php
@@ -150,7 +150,7 @@ trait PowerJoins
                 $relationCallback = $callback[$relationsFullName] ?? $callback[$relationName];
             }
 
-            $alias = $this->getAliasName($useAlias, $relation, $relationName, $query->getModel()->getTable(), $callback, $relationsFullName);
+            $alias = $this->getAliasName($useAlias, $relation, $relationName, $relation->getRelated()->getTable(), $callback, $relationsFullName);
             $aliasString = is_array($alias) ? implode('.', $alias) : $alias;
 
             if ($alias) {


### PR DESCRIPTION
I told about this fix in the last pull request i made. In my office we are making an "Export Builder" for the user...so you can imagine how many imposibles querys the system has to digest...one of them is something like users.practices.offers.company.offers.practices.users ...just to fuck up the system, but i have to support it...because why not

Anyway i have a really bad time with relationships like users.practices.offers and users.practices.language, they dont use the alias correctly

Lets imagine that the alias are the tables...but just with _alias at the end, the relationsip users.practices.offers with join **practices_alias** and **offers_alias**, perfect, but the second one practices.language will join **practices** with **language_alias**, so pratices without the alias...and thats its a problem

I keep digging without knowing to much about the "inside" of this project and for me the problem was that, in a short explanation, that NestedRelathionships doesnt work like the JoinRelathionships in terms of alias. They important part is what alias is using and the "cache" part

To made a join between two tables with alias, the parent one has to be in the cache, and that part work perfect...but just the first time, the second time, with the cache cleaned, the system doesnt have the name of the table, so it just put the original name, breacking the query

Maybe it work only by remoing the cacheClear part, but for me, it seen important...so i modify the joinNested so it use the alias more similar like the joinRelationship...apart of that i made a small change to that function so you can pass, in the callbacks, tables or relationships

Maybe i fucked it big time, but like REALLY big time, and the soluction is fucking simple with the original code...but at least for me is more simple if just the two functions work "mostly" the same...so i made this fucking mess...funny thing is that i have to change my own commit so the tables of one of the test dont brake. All the test are pass...and well my exports work with more that 20-30 left joins with 5-6 level of deeps

PD: I can pass "part" of the export builder, not all of them...if you need it for testing
