### PR TITLE
Fix nested many to many alias, allow callbacks using the full relation name

### DIFF
--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -114,7 +114,7 @@ class PowerJoinClause extends JoinClause
             $table = $this->tableName;
 
             // if it was already replaced, skip
-            if (Str::startsWith($where['first'] . '.', $this->alias) || Str::startsWith($where['second'] . '.', $this->alias)) {
+            if (Str::startsWith($where['first'] . '.', $this->alias . '.') || Str::startsWith($where['second'] . '.', $this->alias . '.')) {
                 return $where;
             }
 

--- a/tests/JoinRelationshipUsingAliasTest.php
+++ b/tests/JoinRelationshipUsingAliasTest.php
@@ -227,4 +227,25 @@ class JoinRelationshipUsingAliasTest extends TestCase
 
         $this->assertStringContainsString('inner join "categories" as "categories_alias" on "post_alias"."category_id" = "categories_alias"."id"', $sql);
     }
+
+    /** @test */
+    public function test_joining_deep_many_to_many_relation_using_same_base_table()
+    {
+        $alias = [
+            'groups' => function ($join) {
+                $join->as('groups_alias');
+            },
+            'posts' => [
+                'post_groups' => function ($join) {
+                    $join->as('post_groups_alias');
+                },
+                'posts' => function ($join) {
+                    $join->as('post_alias');
+                },
+            ]
+        ];
+        $query = User::joinRelationship('groups', $alias)->joinRelationship('groups.posts', $alias);
+        $sql = $query->toSql();
+        $this->assertStringContainsString('inner join "posts" as "post_alias" on "post_alias"."id" = "post_groups_alias"."post_id"', $sql);
+    }
 }


### PR DESCRIPTION
This changes for one part, fix the many to many alias in nested relations. I made a new test in JoinRelationshipUsingAliasTest. I use the same method as the 

The other with the $fullRelationName is an old change but now is a little cleaner. Some times i have relationships that are something like "posts.group.posts" in that case i can't use posts as a key in the callback, because it will be use for posts and posts.group.posts

Checking for posts and latter for posts.group.posts doesnt brake any test, and is only an array and a join extra