### PR TITLE
Fix Polymorphic Many-to-Many joins

### DIFF
--- a/tests/JoinRelationshipExtraConditionsTest.php
+++ b/tests/JoinRelationshipExtraConditionsTest.php
@@ -4,6 +4,7 @@ namespace Kirschbaum\PowerJoins\Tests;
 
 use Kirschbaum\PowerJoins\Tests\Models\Post;
 use Kirschbaum\PowerJoins\Tests\Models\User;
+use Kirschbaum\PowerJoins\Tests\Models\Tag;
 use Kirschbaum\PowerJoins\Tests\Models\Group;
 use Kirschbaum\PowerJoins\Tests\Models\Image;
 use Kirschbaum\PowerJoins\Tests\Models\Comment;
@@ -182,6 +183,52 @@ class JoinRelationshipExtraConditionsTest extends TestCase
             'inner join "images" on "images"."imageable_id" = "posts"."id" and "images"."imageable_type" = ? and "cover" = ?',
             $query
         );
+    }
+
+    /** @test */
+    public function test_extra_conditions_in_morph_to_many()
+    {
+        $tag = factory(Tag::class)->create();
+        $post = factory(Post::class)->create();
+        $comment = factory(Comment::class)->create();
+
+        $tag->posts()->attach($post->id);
+        $tag->comments()->attach($comment->id);
+
+        $postsQuery = Post::joinRelationship('tags');
+        $commentsQuery = Comment::joinRelationship('tags');
+
+        $this->assertCount(1, $postsQuery->get());
+        $this->assertCount(1, $commentsQuery->get());
+
+        $this->assertStringContainsString(
+            'inner join "taggables" on "taggables"."taggable_id" = "posts"."id" and "taggables"."taggable_type" = ?',
+            $postsQuery->toSql()
+        );
+
+        $this->assertStringContainsString(
+            'inner join "taggables" on "taggables"."taggable_id" = "comments"."id" and "taggables"."taggable_type" = ?',
+            $commentsQuery->toSql()
+        );
+    }
+
+    /** @test */
+    public function test_count_in_morph_to_many_left_join()
+    {
+        $tag = factory(Tag::class)->create();
+        $post = factory(Post::class)->create();
+        $comment = factory(Comment::class)->create([
+            'post_id' => $post->id,
+        ]);
+
+        $tag->posts()->attach($post->id);
+        $tag->comments()->attach($comment->id);
+
+        $posts = Post::leftJoinRelationship('tags')->get();
+        $comments = Comment::leftJoinRelationship('tags')->get();
+
+        $this->assertCount(1, $posts);
+        $this->assertCount(1, $comments);
     }
 
     /** @test */

--- a/tests/Models/Comment.php
+++ b/tests/Models/Comment.php
@@ -5,6 +5,7 @@ namespace Kirschbaum\PowerJoins\Tests\Models;
 use Illuminate\Database\Eloquent\Model;
 use Kirschbaum\PowerJoins\PowerJoins;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class Comment extends Model
 {
@@ -21,5 +22,10 @@ class Comment extends Model
     public function post(): BelongsTo
     {
         return $this->belongsTo(Post::class);
+    }
+
+    public function tags(): MorphToMany
+    {
+        return $this->morphToMany(Tag::class, 'taggable');
     }
 }

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class Post extends Model
 {
@@ -43,6 +44,11 @@ class Post extends Model
     public function coverImages(): MorphMany
     {
         return $this->morphMany(Image::class, 'imageable')->where('cover', true);
+    }
+
+    public function tags(): MorphToMany
+    {
+        return $this->morphToMany(Tag::class, 'taggable');
     }
 
     public function category(): BelongsTo

--- a/tests/Models/Tag.php
+++ b/tests/Models/Tag.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kirschbaum\PowerJoins\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Kirschbaum\PowerJoins\PowerJoins;
+
+class Tag extends Model
+{
+    use PowerJoins;
+
+    /** @var string */
+    protected $table = 'tags';
+
+    public function posts(): MorphToMany
+    {
+        return $this->morphedByMany(Post::class, 'taggable');
+    }
+
+    public function comments(): MorphToMany
+    {
+        return $this->morphedByMany(Comment::class, 'taggable');
+    }
+}

--- a/tests/database/factories/TagFactory.php
+++ b/tests/database/factories/TagFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+use Kirschbaum\PowerJoins\Tests\Models\Tag;
+
+$factory->define(Tag::class, function (Faker\Generator $faker) {
+    return [
+        'name' => $faker->words(3, true),
+    ];
+});

--- a/tests/database/migrations/2020_03_16_000000_create_tables.php
+++ b/tests/database/migrations/2020_03_16_000000_create_tables.php
@@ -84,6 +84,17 @@ class CreateTables extends Migration
             $table->boolean('cover')->default(false);
             $table->timestamps();
         });
+
+        Schema::create('tags', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('taggables', function (Blueprint $table) {
+            $table->foreignId('tag_id');
+            $table->morphs('taggable');
+        });
     }
 
     /**


### PR DESCRIPTION
This creates a new method `performJoinForEloquentPowerJoinsForMorphToMany` in `Kirschbaum\PowerJoins\Mixins\RelationshipsExtraMethods` class to correctly handle polymorphic many-to-many relationships.

While the MorphToMany was being handled by the `performJoinForEloquentPowerJoinsForBelongsToMany`, the morph type column query where clause was added to the relation model table join and not the pivot table.

Closes #136 