### PR TITLE
feat: support for statically added closure global scopes

### DIFF
--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -91,6 +91,11 @@ class PowerJoinClause extends JoinClause
         }
 
         foreach ($this->model->getGlobalScopes() as $scope) {
+            if ($scope instanceof Closure) {
+                $scope->call($this, $this);
+                continue;
+            }
+
             (new $scope())->apply($this, $this->model);
         }
 

--- a/tests/JoinWithGlobalScopeTest.php
+++ b/tests/JoinWithGlobalScopeTest.php
@@ -2,15 +2,10 @@
 
 namespace Kirschbaum\PowerJoins\Tests;
 
-use Kirschbaum\PowerJoins\PowerJoins;
-use Kirschbaum\PowerJoins\Tests\Models\Post;
-use Kirschbaum\PowerJoins\Tests\Models\User;
-use Kirschbaum\PowerJoins\Tests\Models\Image;
-use Kirschbaum\PowerJoins\Tests\Models\Comment;
-use Kirschbaum\PowerJoins\Tests\Models\Category;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Kirschbaum\PowerJoins\Tests\Models\UserProfile;
+use Kirschbaum\PowerJoins\Tests\Models\PostWithClosureGlobalScope;
 use Kirschbaum\PowerJoins\Tests\Models\PostWithGlobalScope;
+use Kirschbaum\PowerJoins\Tests\Models\User;
 
 class JoinWithGlobalScopeTest extends TestCase
 {
@@ -21,6 +16,21 @@ class JoinWithGlobalScopeTest extends TestCase
             public function posts(): HasMany
             {
                 return $this->hasMany(PostWithGlobalScope::class, 'user_id');
+            }
+        };
+
+        $this->assertCount(0, $user->query()->joinRelationship('posts', fn ($join) => $join->withGlobalScopes())->get());
+
+        $query = $user->query()->joinRelationship('posts', fn ($join) => $join->withGlobalScopes())->toSql();
+        $this->assertStringContainsString('"posts"."published" = ?', $query);
+    }
+
+    public function test_join_with_closure_global_scope_applied()
+    {
+        $user = new class extends User {
+            public function posts(): HasMany
+            {
+                return $this->hasMany(PostWithClosureGlobalScope::class, 'user_id');
             }
         };
 

--- a/tests/Models/PostWithClosureGlobalScope.php
+++ b/tests/Models/PostWithClosureGlobalScope.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Kirschbaum\PowerJoins\Tests\Models;
+
+class PostWithClosureGlobalScope extends Post
+{
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('published', function ($builder) {
+            $builder->where('posts.published', true);
+        });
+    }
+}


### PR DESCRIPTION
Adds support for statically added Closure global scopes.

Example:
```php
protected static function boot()
{
    parent::boot();

    static::addGlobalScope('order', function ($builder) {
        $builder->orderBy('first_name')->orderBy('last_name');
    });
}
```

This would throw a `Instantiation of 'Closure' is not allowed` before.