### PR TITLE
Fix for the issue 148 - Join sometimes not applied

### DIFF
--- a/src/JoinsHelper.php
+++ b/src/JoinsHelper.php
@@ -17,7 +17,15 @@ class JoinsHelper
 
     public static function make(): static
     {
-        $objects = array_map(fn ($object) => spl_object_id($object), func_get_args());
+        $objects = array_map(
+            function ($object) {
+                if ( ! $object->powerJoinsInstanceId ?? null) {
+                    $object->powerJoinsInstanceId = uniqid();
+                }
+                return $object->powerJoinsInstanceId;
+            },
+            func_get_args()
+        );
 
         return static::$instances[implode('-', $objects)] ??= new self();
     }
@@ -107,7 +115,7 @@ class JoinsHelper
      */
     public function relationshipAlreadyJoined($model, string $relation): bool
     {
-        return isset($this->joinRelationshipCache[spl_object_id($model)][$relation]);
+        return isset($this->joinRelationshipCache[$model->powerJoinsInstanceId][$relation]);
     }
 
     /**
@@ -115,6 +123,6 @@ class JoinsHelper
      */
     public function markRelationshipAsAlreadyJoined($model, string $relation): void
     {
-        $this->joinRelationshipCache[spl_object_id($model)][$relation] = true;
+        $this->joinRelationshipCache[$model->powerJoinsInstanceId][$relation] = true;
     }
 }

--- a/src/StaticCache.php
+++ b/src/StaticCache.php
@@ -14,12 +14,16 @@ class StaticCache
 
     public static function getTableOrAliasForModel(Model $model): string
     {
-        return static::$powerJoinAliasesCache[spl_object_id($model)] ?? $model->getTable();
+        if (property_exists($model, 'powerJoinsInstanceId') && isset(static::$powerJoinAliasesCache[$model->powerJoinsInstanceId])) {
+            return static::$powerJoinAliasesCache[$model->powerJoinsInstanceId];
+        } else {
+            return $model->getTable();
+        }
     }
 
     public static function setTableAliasForModel(Model $model, $alias): void
     {
-        static::$powerJoinAliasesCache[spl_object_id($model)] = $alias;
+        static::$powerJoinAliasesCache[$model->powerJoinsInstanceId] = $alias;
     }
 
     public static function clear(): void


### PR DESCRIPTION
Fixed problem when spl_object_id works incorrectly with garbage collector. In case if we use joinRelation for a collection of objects spl_object_id can return id that is already used. 