### PR TITLE
Fix faulty default `WHERE` clause & column checks for joins on `MorphTo` relation

### DIFF
--- a/src/Mixins/JoinRelationship.php
+++ b/src/Mixins/JoinRelationship.php
@@ -117,6 +117,7 @@ class JoinRelationship
 
             $relation = $this->getModel()->{$relationName}();
             $relationQuery = $relation->getQuery();
+            $relationQuery->getQuery()->wheres = [];
             $alias = $joinHelper->getAliasName($useAlias, $relation, $relationName,
                 $relationQuery->getModel()->getTable(), $callback);
 

--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -494,6 +494,13 @@ class RelationshipsExtraMethods
     public function getPowerJoinExistenceCompareKey()
     {
         return function () {
+            if ($this instanceof MorphTo) {
+                return [
+                    $this->getModel()->qualifyColumn($this->getMorphType()),
+                    $this->getQualifiedForeignKeyName()
+                ];
+            }
+
             if ($this instanceof BelongsTo) {
                 return $this->getQualifiedOwnerKeyName();
             }


### PR DESCRIPTION
Fixes #160 

For info, see the comments with the commits