### PR TITLE
(ci) test with lowest dependency required version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,8 +57,8 @@ jobs:
             -   name: Install dependencies
                 run: |
                     composer --version
-                    composer require ${{ matrix.dependency-version }} "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-                    composer require ${{ matrix.dependency-version }} "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
+                    composer require "laravel/framework:${{ matrix.laravel }}" ${{ matrix.dependency-version }} --no-interaction --no-update
+                    composer require "orchestra/testbench:${{ matrix.testbench }}" ${{ matrix.dependency-version }} --no-interaction --no-update --dev
                     composer update ${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest --dev
                     composer dump
 
@@ -120,8 +120,8 @@ jobs:
             -   name: Install dependencies
                 run: |
                     composer --version
-                    composer require ${{ matrix.dependency-version }} "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-                    composer require ${{ matrix.dependency-version }} "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
+                    composer require "laravel/framework:${{ matrix.laravel }}" ${{ matrix.dependency-version }} --no-interaction --no-update
+                    composer require "orchestra/testbench:${{ matrix.testbench }}" ${{ matrix.dependency-version }} --no-interaction --no-update --dev
                     composer update ${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest --dev
                     composer dump
 
@@ -175,8 +175,8 @@ jobs:
             -   name: Install dependencies
                 run: |
                     composer --version
-                    composer require ${{ matrix.dependency-version }} "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-                    composer require ${{ matrix.dependency-version }} "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
+                    composer require "laravel/framework:${{ matrix.laravel }}" ${{ matrix.dependency-version }} --no-interaction --no-update
+                    composer require "orchestra/testbench:${{ matrix.testbench }}" ${{ matrix.dependency-version }} --no-interaction --no-update --dev
                     composer update ${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest --dev
                     composer dump
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
             fail-fast: true
             matrix:
                 php: [ 8.1, 8.2, 8.3 ]
-                laravel: [ 10.*, 11.* ]
+                laravel: [ ^10.0, ^11.0 ]
                 dependency-version: [ --prefer-lowest --prefer-stable, '' ]
                 include:
                     -   laravel: ^11.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,4 +189,4 @@ jobs:
                 run: vendor/bin/phpunit
                 env:
                     DB_CONNECTION: sqlite
-                    DB_DATABASE: :memory:
+                    DB_DATABASE: ":memory:"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
             fail-fast: true
             matrix:
                 php: [ 8.1, 8.2, 8.3 ]
-                laravel: [ 10.*, 11.* ]
+                laravel: [ ^10.0, ^11.0 ]
                 dependency-version: [ --prefer-lowest --prefer-stable, '' ]
                 include:
                     -   laravel: ^11.0
@@ -141,7 +141,7 @@ jobs:
             fail-fast: true
             matrix:
                 php: [ 8.1, 8.2, 8.3 ]
-                laravel: [ 10.*, 11.* ]
+                laravel: [ ^10.0, ^11.0 ]
                 dependency-version: [ --prefer-lowest --prefer-stable, '' ]
                 include:
                     -   laravel: ^11.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,8 @@ jobs:
                 run: vendor/bin/phpunit
                 env:
                     DB_CONNECTION: mysql
+                    DB_DATABASE: laravel
+                    DB_USERNAME: root
 
     pgsql_15:
         runs-on: ubuntu-24.04
@@ -187,3 +189,4 @@ jobs:
                 run: vendor/bin/phpunit
                 env:
                     DB_CONNECTION: sqlite
+                    DB_DATABASE: :memory:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,13 +24,14 @@ jobs:
             matrix:
                 php: [ 8.1, 8.2, 8.3 ]
                 laravel: [ 10.*, 11.* ]
+                dependency-version: [ --prefer-lowest --prefer-stable, '' ]
                 include:
-                    -   laravel: 11.*
-                        testbench: 9.*-dev
-                    -   laravel: 10.*
-                        testbench: 8.*
+                    -   laravel: ^11.0
+                        testbench: ^9.0
+                    -   laravel: ^10.0
+                        testbench: ^8.0
                 exclude:
-                    -   laravel: 11.*
+                    -   laravel: ^11.0
                         php: 8.1
 
         name: MySQL 8 - PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
@@ -39,23 +40,27 @@ jobs:
             -   name: Checkout code
                 uses: actions/checkout@v4
 
+            -   name: Cache dependencies
+                uses: actions/cache@v1
+                with:
+                    path: ~/.composer/cache/files
+                    key: dependencies-pw-v2-${{ matrix.laravel }}-php-${{ matrix.php }}${{matrix.dependency-version}}-composer-${{ hashFiles('composer.json') }}
+
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.2
-                    extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_mysql, :php-psr
-                    tools: composer:v2
+                    php-version: ${{ matrix.php }}
+                    extensions: curl, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, iconv
                     coverage: none
-
-            -   name: Set Framework version
-                run: composer config version "11.x-dev"
+                    tools: composer:v2
 
             -   name: Install dependencies
-                uses: nick-fields/retry@v3
-                with:
-                    timeout_minutes: 5
-                    max_attempts: 5
-                    command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+                run: |
+                    composer --version
+                    composer require ${{ matrix.dependency-version }} "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+                    composer require ${{ matrix.dependency-version }} "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
+                    composer update ${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest --dev
+                    composer dump
 
             -   name: Execute tests
                 run: vendor/bin/phpunit
@@ -82,13 +87,14 @@ jobs:
             matrix:
                 php: [ 8.1, 8.2, 8.3 ]
                 laravel: [ 10.*, 11.* ]
+                dependency-version: [ --prefer-lowest --prefer-stable, '' ]
                 include:
-                    -   laravel: 11.*
-                        testbench: 9.*-dev
-                    -   laravel: 10.*
-                        testbench: 8.*
+                    -   laravel: ^11.0
+                        testbench: ^9.0
+                    -   laravel: ^10.0
+                        testbench: ^8.0
                 exclude:
-                    -   laravel: 11.*
+                    -   laravel: ^11.0
                         php: 8.1
 
         name: PostgreSQL 15 - PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
@@ -101,7 +107,7 @@ jobs:
                 uses: actions/cache@v1
                 with:
                     path: ~/.composer/cache/files
-                    key: dependencies-pw-v2-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+                    key: dependencies-pw-v2-${{ matrix.laravel }}-php-${{ matrix.php }}${{matrix.dependency-version}}-composer-${{ hashFiles('composer.json') }}
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -114,9 +120,9 @@ jobs:
             -   name: Install dependencies
                 run: |
                     composer --version
-                    composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-                    composer require "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
-                    composer update --prefer-dist --no-interaction --no-suggest --dev
+                    composer require ${{ matrix.dependency-version }} "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+                    composer require ${{ matrix.dependency-version }} "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
+                    composer update ${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest --dev
                     composer dump
 
             -   name: Execute tests
@@ -136,13 +142,14 @@ jobs:
             matrix:
                 php: [ 8.1, 8.2, 8.3 ]
                 laravel: [ 10.*, 11.* ]
+                dependency-version: [ --prefer-lowest --prefer-stable, '' ]
                 include:
-                    -   laravel: 11.*
-                        testbench: 9.*-dev
-                    -   laravel: 10.*
-                        testbench: 8.*
+                    -   laravel: ^11.0
+                        testbench: ^9.0
+                    -   laravel: ^10.0
+                        testbench: ^8.0
                 exclude:
-                    -   laravel: 11.*
+                    -   laravel: ^11.0
                         php: 8.1
 
         name: SQLite - PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
@@ -155,7 +162,7 @@ jobs:
                 uses: actions/cache@v1
                 with:
                     path: ~/.composer/cache/files
-                    key: dependencies-pw-v2-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+                    key: dependencies-pw-v2-${{ matrix.laravel }}-php-${{ matrix.php }}${{matrix.dependency-version}}-composer-${{ hashFiles('composer.json') }}
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -168,9 +175,9 @@ jobs:
             -   name: Install dependencies
                 run: |
                     composer --version
-                    composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-                    composer require "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
-                    composer update --prefer-dist --no-interaction --no-suggest --dev
+                    composer require ${{ matrix.dependency-version }} "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+                    composer require ${{ matrix.dependency-version }} "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
+                    composer update ${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest --dev
                     composer dump
 
             -   name: Setup SQLite Database

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/support": "^8.75|^9.0|^10.0|^11.0",
-        "illuminate/database": "^8.75|^9.0|^10.0|^11.0"
+        "php": "^8.1",
+        "illuminate/support": "^10.0|^11.0",
+        "illuminate/database": "^10.0|^11.0"
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0@dev",
-        "orchestra/testbench": "^6.24|^7.0|^8.0|^9.0",
-        "phpunit/phpunit": "^9.5|^10.0"
+        "orchestra/testbench": "^8.0|^9.0",
+        "phpunit/phpunit": "^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0",
-        "illuminate/database": "^10.0|^11.0"
+        "php": "^8.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0@dev",
-        "orchestra/testbench": "^8.0|^9.0",
-        "phpunit/phpunit": "^10.0"
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
+        "phpunit/phpunit": "^9.3|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
-        "illuminate/database": "^8.0|^9.0|^10.0|^11.0"
+        "illuminate/support": "^8.75|^9.0|^10.0|^11.0",
+        "illuminate/database": "^8.75|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0@dev",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0@dev",
-        "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^6.24|^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.5|^10.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0@dev",
-        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
-        "phpunit/phpunit": "^9.3|^10.0"
+        "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0",
+        "phpunit/phpunit": "^9.5|^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
At the moment we install all our dependencies with the highest minor & patch number.  
Because this project support all major versions from the beginning (`X.0`) we should also test these specific versions too.

There is a composer command which will help us: `--prefer-lowest`
From the [composer docs](https://getcomposer.org/doc/03-cli.md) it suggest to also include `--prefer-stable`