### PR TITLE
fix: allow non nested joins to specify pivot information

### DIFF
--- a/tests/JoinRelationshipTest.php
+++ b/tests/JoinRelationshipTest.php
@@ -537,8 +537,8 @@ class JoinRelationshipTest extends TestCase
     {
         $query = User::joinRelationship('commentsThroughPosts.user', [
             'commentsThroughPosts' => [
-                'posts' => fn($join) => $join->as('posts_alias'),
-                'comments' => fn($join) => $join->as('comments_alias'),
+                'posts' => fn ($join) => $join->as('posts_alias'),
+                'comments' => fn ($join) => $join->as('comments_alias'),
             ],
         ])->toSql();
 
@@ -558,8 +558,8 @@ class JoinRelationshipTest extends TestCase
     {
         $query = Group::joinRelationship('posts.user', [
             'posts' => [
-                'posts' => fn($join) => $join->as('posts_alias'),
-                'post_groups' => fn($join) => $join->as('post_groups_alias'),
+                'posts' => fn ($join) => $join->as('posts_alias'),
+                'post_groups' => fn ($join) => $join->as('post_groups_alias'),
             ],
         ])->toSql();
 
@@ -570,6 +570,27 @@ class JoinRelationshipTest extends TestCase
 
         $this->assertStringContainsString(
             'inner join "post_groups" as "post_groups_alias"',
+            $query
+        );
+    }
+
+    /** @test */
+    public function test_join_belongs_to_many_with_alias()
+    {
+        $query = Group::joinRelationship('posts', [
+            'posts' => [
+                'posts' => fn ($join) => $join->as('posts_alias'),
+                'post_groups' => fn ($join) => $join->as('post_groups_not_nested'),
+            ],
+        ])->toSql();
+
+        $this->assertStringContainsString(
+            'inner join "posts" as "posts_alias"',
+            $query
+        );
+
+        $this->assertStringContainsString(
+            'inner join "post_groups" as "post_groups_not_nested"',
             $query
         );
     }


### PR DESCRIPTION
On a personal project I was trying to change some properties of the pivot as in the README example
```
User::joinRelationship('groups', [
    'groups' => [
        'groups' => function ($join) {
            // ...
        },
        // group_members is the intermediary table here
        'group_members' => fn ($join) => $join->where('group_members.active', true),
    ]
]);
```
but it was erroring out with the following error (reproduced in the repo).

```
     ├ Error: Array callback has to contain indices 0 and 1
     │ 
     │ eloquent-power-joins/src/JoinsHelper.php:88
     │ eloquent-power-joins/src/Mixins/JoinRelationship.php:125
     │ eloquent-power-joins/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:1961
     │ eloquent-power-joins/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php:23
     │ eloquent-power-joins/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:2334
     │ eloquent-power-joins/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:2346
     │ eloquent-power-joins/tests/JoinRelationshipTest.php:583
     ┴ 
```

I then noticed that the test case in the repo `test_join_belongs_to_many_relationship_with_alias` was technically covering the flow, but it was doing when specifying also a nested additional property.

I've copy pasted a bit the handling of the $callback from the `joinNestedRelationship` and things do seem to succed, but I am concerned about the extra is_array I had to add to make tests pass

PS:
There are some slight formatting changes, but I blame the auto-formatter on following PSR-2, from what i noticed they were outliers since the other methods do use the same formatting style, if you think it's a problem please let me know and I'll remove them