### PR TITLE
Support HasOneThrough

### DIFF
--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 /**
@@ -61,7 +62,7 @@ class RelationshipsExtraMethods
                 $this instanceof BelongsToMany => $this->performJoinForEloquentPowerJoinsForBelongsToMany($builder, $joinType, $callback, $alias, $disableExtraConditions),
                 $this instanceof MorphOneOrMany => $this->performJoinForEloquentPowerJoinsForMorph($builder, $joinType, $callback, $alias, $disableExtraConditions),
                 $this instanceof HasMany || $this instanceof HasOne => $this->performJoinForEloquentPowerJoinsForHasMany($builder, $joinType, $callback, $alias, $disableExtraConditions),
-                $this instanceof HasManyThrough => $this->performJoinForEloquentPowerJoinsForHasManyThrough($builder, $joinType, $callback, $alias, $disableExtraConditions),
+                $this instanceof HasManyThrough || $this instanceof HasOneThrough => $this->performJoinForEloquentPowerJoinsForHasManyThrough($builder, $joinType, $callback, $alias, $disableExtraConditions),
                 $this instanceof MorphTo => $this->performJoinForEloquentPowerJoinsForMorphTo($builder, $joinType, $callback, $alias, $disableExtraConditions, $morphable),
                 default => $this->performJoinForEloquentPowerJoinsForBelongsTo($builder, $joinType, $callback, $alias, $disableExtraConditions),
             };
@@ -532,7 +533,7 @@ class RelationshipsExtraMethods
                 return $this->getExistenceCompareKey();
             }
 
-            if ($this instanceof HasManyThrough) {
+            if ($this instanceof HasManyThrough || $this instanceof HasOneThrough) {
                 return $this->getQualifiedFirstKeyName();
             }
 

--- a/tests/Models/Comment.php
+++ b/tests/Models/Comment.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Kirschbaum\PowerJoins\PowerJoins;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 
 class Comment extends Model
 {
@@ -27,5 +28,17 @@ class Comment extends Model
     public function tags(): MorphToMany
     {
         return $this->morphToMany(Tag::class, 'taggable');
+    }
+
+    public function postCategory(): HasOneThrough
+    {
+        return $this->hasOneThrough(
+            Category::class,
+            Post::class,
+            'id',
+            'id',
+            'post_id',
+            'category_id'
+        );
     }
 }


### PR DESCRIPTION
In Laravel v11.15 the underlying `HasOneThrough` class changed from `HasManyThrough` to `HasOneOrManyThrough` (in https://github.com/laravel/framework/pull/51851).

Which caused the package to start using `performJoinForEloquentPowerJoinsForBelongsTo` instead of `performJoinForEloquentPowerJoinsForHasManyThrough` causing a `Undefined property: Illuminate\Database\Eloquent\Relations\HasOneThrough::$foreignKey` exception.

This PR adds support back for `HasOneThrough`. I decided to not use the `HasOneOrManyThrough` class directly in the match statement since that class does not exist in older Laravel versions.