### PR TITLE
fix: include soft delete conditions when using named aliases

### DIFF
--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -120,7 +120,7 @@ class PowerJoinClause extends JoinClause
             if ($whereType === 'Null' && Str::contains($where['column'], $this->getModel()->getDeletedAtColumn())) {
                 return true;
             }
-            
+
             return false;
         })->map(function ($where) {
             if ($where['type'] === 'Null') {

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -111,8 +111,22 @@ class PowerJoinClause extends JoinClause
         }
 
         $this->wheres = collect($this->wheres)->filter(function ($where) {
-            return in_array($where['type'] ?? '', ['Column', 'Basic'], true);
+            $whereType = $where['type'] ?? '';
+
+            if (in_array($whereType, ['Column', 'Basic'], true)) {
+                return true;
+            }
+
+            if ($whereType === 'Null' && Str::contains($where['column'], $this->getModel()->getDeletedAtColumn())) {
+                return true;
+            }
+            
+            return false;
         })->map(function ($where) {
+            if ($where['type'] === 'Null') {
+                return $where;
+            }
+
             $key = $this->model->getKeyName();
             $table = $this->tableName;
             $replaceMethod = sprintf('useAliasInWhere%sType', ucfirst($where['type']));

--- a/tests/JoinRelationshipTest.php
+++ b/tests/JoinRelationshipTest.php
@@ -793,7 +793,7 @@ class JoinRelationshipTest extends TestCase
         );
 
         $this->assertQueryContains(
-            'inner join "posts" as "posts_1" on "posts_1"."id" = "pivot_posts_1"."post_id" and "posts_1"."id" = ?',
+            'inner join "posts" as "posts_1" on "posts_1"."id" = "pivot_posts_1"."post_id" and "posts_1"."deleted_at" is null and "posts_1"."id" = ?',
             $sql
         );
     }

--- a/tests/JoinRelationshipUsingAliasTest.php
+++ b/tests/JoinRelationshipUsingAliasTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirschbaum\PowerJoins\Tests;
 
+use Kirschbaum\PowerJoins\PowerJoinClause;
 use Kirschbaum\PowerJoins\Tests\Models\Category;
 use Kirschbaum\PowerJoins\Tests\Models\Comment;
 use Kirschbaum\PowerJoins\Tests\Models\Group;
@@ -266,5 +267,23 @@ class JoinRelationshipUsingAliasTest extends TestCase
             'inner join "images" as "foo" on "foo"."imageable_id" = "posts"."id" and "foo"."imageable_type" = ?',
             $query
         );
+    }
+
+    /** @test */
+    public function test_join_model_with_soft_deletes_using_alias()
+    {
+        $queryA = UserProfile::query()->joinRelationshipUsingAlias('user', 'user_alias')->toSql();
+        $queryB = UserProfile::query()->joinRelationship('user', 'user_alias')->toSql();
+        $queryC = UserProfile::query()->joinRelationship(
+            'user',
+            fn (PowerJoinClause $join) => $join->as('user_alias')
+        )->toSql();
+
+        $this->assertQueryContains(
+            $expected = 'inner join "users" as "user_alias" on "user_profiles"."user_id" = "user_alias"."id" and "user_alias"."deleted_at" is null',
+            $queryA
+        );
+        $this->assertQueryContains($expected, $queryB);
+        $this->assertQueryContains($expected, $queryC);
     }
 }

--- a/tests/OrderByTest.php
+++ b/tests/OrderByTest.php
@@ -209,7 +209,7 @@ class OrderByTest extends TestCase
         ]);
 
         $this->assertQueryContains(
-            'select "users".* from "users" inner join "posts" as "posts_alias" on "posts_alias"."user_id" = "users"."id" inner join "categories" as "category_alias" on "posts_alias"."category_id" = "category_alias"."id" where "users"."deleted_at" is null order by "category_alias"."title" desc',
+            'select "users".* from "users" inner join "posts" as "posts_alias" on "posts_alias"."user_id" = "users"."id" and "posts_alias"."deleted_at" is null inner join "categories" as "category_alias" on "posts_alias"."category_id" = "category_alias"."id" where "users"."deleted_at" is null order by "category_alias"."title" desc',
             $query->toSql()
         );
 


### PR DESCRIPTION
When joining a relationship using an alias on a model with soft deletes like:
```
UserProfile::query()->joinRelationshipUsingAlias('user')
```

We get a query thats looks like:
```
SELECT "user_profiles".*
FROM "user_profiles"
INNER JOIN "users" AS "bd9404474a249ec9062d489a4b265c44" 
	ON "user_profiles"."user_id" = "bd9404474a249ec9062d489a4b265c44"."id" 
	AND "bd9404474a249ec9062d489a4b265c44"."deleted_at" IS NULL
```

So I would expect that when using a named alias like:
```
UserProfile::query()->joinRelationshipUsingAlias('user', 'user_alias')
```

The `deleted_at` conditions for the `User` model would still be used, but instead I'm seeing a query like:
```
SELECT "user_profiles".*
FROM "user_profiles" INNER JOIN "users" AS "user_alias" 
	ON "user_profiles"."user_id" = "user_alias"."id"
```

I noticed that the `useTableAliasInConditions` method on the `PowerJoinClause` is filtering out the soft delete conditions.
I modified this method so it includes the soft delete conditions and also added some tests covering different ways to use named aliases.