### PR TITLE
Fix alias not fully applying in has one/many through

### DIFF
--- a/tests/JoinRelationshipUsingAliasTest.php
+++ b/tests/JoinRelationshipUsingAliasTest.php
@@ -286,4 +286,43 @@ class JoinRelationshipUsingAliasTest extends TestCase
         $this->assertQueryContains($expected, $queryB);
         $this->assertQueryContains($expected, $queryC);
     }
+
+    /** @test */
+    public function test_join_through_model_with_soft_deletes_using_alias()
+    {
+        // has one through
+        $query = Comment::query()->joinRelationship('postCategory', [
+            'postCategory' => [
+                'posts' => fn ($join) => $join->as('posts_alias'),
+            ],
+        ])->toSql();
+
+        $this->assertQueryContains(
+            $expected = 'select comments.* from comments inner join posts as posts_alias on posts_alias.id = comments.post_id and posts_alias.deleted_at is null inner join categories on categories.id = posts_alias.category_id',
+            $query
+        );
+
+        // has many through
+        $query = User::query()->joinRelationship('commentsThroughPosts', [
+            'comments' => fn ($join) => $join->as('comments_alias'),
+            'posts' => fn ($join) => $join->as('posts_alias'),
+        ])->toSql();
+
+        $this->assertQueryContains(
+            $expected = 'select "users".* from "users" inner join "posts" as "posts_alias" on "posts_alias"."user_id" = "users"."id" and "posts_alias"."deleted_at" is null inner join "comments" as "comments_alias" on "comments_alias"."post_id" = "posts_alias"."id" where "users"."deleted_at" is null',
+            $query
+        );
+
+        // ensure for nested relation too
+        $query = Post::query()->joinRelationship('lastComment.postCategory', [
+            'postCategory' => [
+                'posts' => fn ($join) => $join->as('posts_alias'),
+            ],
+        ])->toSql();
+
+        $this->assertQueryContains(
+            $expected = 'select "posts".* from "posts" inner join "comments" on "comments"."post_id" = "posts"."id" inner join "posts" as "posts_alias" on "posts_alias"."id" = "comments"."post_id" and "posts_alias"."deleted_at" is null inner join "categories" on "categories"."id" = "posts_alias"."category_id" where ("comments"."id" in (select distinct "comments"."id" from "comments" where "comments"."post_id" = "posts"."id" order by "comments"."id" desc limit 1)) and "posts"."deleted_at" is null',
+            $query
+        );
+    }
 }

--- a/tests/JoinRelationshipUsingAliasTest.php
+++ b/tests/JoinRelationshipUsingAliasTest.php
@@ -321,7 +321,17 @@ class JoinRelationshipUsingAliasTest extends TestCase
         ])->toSql();
 
         $this->assertQueryContains(
-            $expected = 'select "posts".* from "posts" inner join "comments" on "comments"."post_id" = "posts"."id" inner join "posts" as "posts_alias" on "posts_alias"."id" = "comments"."post_id" and "posts_alias"."deleted_at" is null inner join "categories" on "categories"."id" = "posts_alias"."category_id" where ("comments"."id" in (select distinct "comments"."id" from "comments" where "comments"."post_id" = "posts"."id" order by "comments"."id" desc limit 1)) and "posts"."deleted_at" is null',
+            $expected = 'select "posts".* from "posts"',
+            $query
+        );
+
+        $this->assertQueryContains(
+            $expected = 'inner join "posts" as "posts_alias" on "posts_alias"."id" = "comments"."post_id" and "posts_alias"."deleted_at"',
+            $query
+        );
+
+        $this->assertQueryContains(
+            $expected = 'inner join "categories" on "categories"."id" = "posts_alias"."category_id"',
             $query
         );
     }


### PR DESCRIPTION
Aliases correctly apply on the join part, but not on the soft deletes bit or any subsequent joins.

Please let me know if I've missed something!

<img width="2546" alt="Screenshot 2025-03-08 at 00 12 45" src="https://github.com/user-attachments/assets/c926882d-7be5-4125-a5ae-a557a6adbdb9" />
