### PR TITLE
Fix missing alias in soft deletes in oneThrough / manyThrough / morphOne / morphMany

### DIFF
--- a/src/JoinsHelper.php
+++ b/src/JoinsHelper.php
@@ -188,10 +188,10 @@ class JoinsHelper
                     }
                 }
 
-                $farParentTable = $relation->getFarParent()->getTable();
-                if (isset($callback[$farParentTable])) {
-                    $fakeJoinCallback = new FakeJoinCallback($relation->getBaseQuery(), 'inner', $farParentTable);
-                    $callback[$farParentTable]($fakeJoinCallback);
+                $relatedTable = $relation->getRelated()->getTable();
+                if (isset($callback[$relatedTable])) {
+                    $fakeJoinCallback = new FakeJoinCallback($relation->getBaseQuery(), 'inner', $relatedTable);
+                    $callback[$relatedTable]($fakeJoinCallback);
 
                     if ($fakeJoinCallback->getAlias()) {
                         $alias[1] = $fakeJoinCallback->getAlias();

--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -223,7 +223,11 @@ class RelationshipsExtraMethods
     protected function performJoinForEloquentPowerJoinsForMorph()
     {
         return function ($builder, $joinType, $callback = null, $alias = null, bool $disableExtraConditions = false) {
-            $builder->{$joinType}($this->getModel()->getTable(), function ($join) use ($callback, $disableExtraConditions) {
+            $builder->{$joinType}($this->getModel()->getTable(), function ($join) use ($callback, $disableExtraConditions, $alias) {
+                if ($alias) {
+                    $join->as($alias);
+                }
+
                 $join->on(
                     "{$this->getModel()->getTable()}.{$this->getForeignKeyName()}",
                     '=',

--- a/tests/Models/Like.php
+++ b/tests/Models/Like.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Kirschbaum\PowerJoins\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Like extends Model
+{
+    use SoftDeletes;
+    /** @var string */
+    protected $table = 'likes';
+
+    public function likeable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -57,6 +57,11 @@ class Post extends Model
         return $this->morphMany(Image::class, 'imageable');
     }
 
+    public function likes(): MorphMany
+    {
+        return $this->morphMany(Like::class, 'likeable');
+    }
+
     public function coverImages(): MorphMany
     {
         return $this->morphMany(Image::class, 'imageable')->where('cover', true);

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -68,6 +68,11 @@ class User extends Model
         return $this->hasManyThrough(Comment::class, Post::class);
     }
 
+    public function postsThroughComments(): HasManyThrough
+    {
+        return $this->hasManyThrough(Post::class, Comment::class);
+    }
+
     public function images(): MorphMany
     {
         return $this->morphMany(Image::class, 'imageable');

--- a/tests/database/migrations/2020_03_16_000000_create_tables.php
+++ b/tests/database/migrations/2020_03_16_000000_create_tables.php
@@ -94,6 +94,13 @@ class CreateTables extends Migration
             $table->softDeletes();
         });
 
+        Schema::create('likes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->morphs('likeable');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
         Schema::create('tags', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');


### PR DESCRIPTION
In a `hasOneThrough`/`hasManyThrough` relation, it would not apply an alias to the related table.

```php
class Comment # 1: farParent
{
    public function postCategory(): HasOneThrough
    {
                                  # 2: related       3: through
        return $this->hasOneThrough(Category::class, Post::class);
    }
}
```

Instead, it would look for a potential alias of the 'farParent' but I think this is unintentional. It should look for alias in the 'through' relation (it already did that) and the 'related' relation (it does after this change)

Second fix is for #209 and applies missing alias in soft deletes for `morphOne`/`morphMany`.


PS, i added a new Like model because I need to test soft deletes. I didn't want to add SoftDeletes to another model because it would mean many existing tests needed to be changed.