### PR TITLE
Exclude files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,11 +2,12 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
+/.github            export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /.travis.yml        export-ignore
 /phpunit.xml.dist   export-ignore
 /.scrutinizer.yml   export-ignore
-/tests              export-ignore
 /screenshots        export-ignore
+/tests              export-ignore
 /.editorconfig      export-ignore


### PR DESCRIPTION
There is 140KB of screenshots included when requiring the composer package. I dont think it is beneficial to have them in your vendor directory.

Additionally, the `.github` directory isnt needed either.