### PR TITLE
fix alias not applying in "through" joins when referencing the same table twice

### DIFF
--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -377,10 +377,11 @@ class RelationshipsExtraMethods
                     $join->as($alias1);
                 }
 
+                $farParentTable = StaticCache::getTableOrAliasForModel($this->getFarParent());
                 $join->on(
                     "{$throughTable}.{$this->getFirstKeyName()}",
                     '=',
-                    $this->getQualifiedLocalKeyName()
+                    "{$farParentTable}.{$this->localKey}"
                 );
 
                 if ($disableExtraConditions === false && $this->usesSoftDeletes($this->getThroughParent())) {


### PR DESCRIPTION
#### Preserve aliases in nested "through" joins when referencing the same table multiple times

While upgrading an older Laravel package and in turn eloquent-power-joins, a few of our queries broke because nested "through" relationships no longer respected table aliases when the same table was joined multiple times.

Example:
```
Comment::joinRelationship('user.commentsThroughPosts', [
    'user' => fn ($join) => $join->as('users_alias')->withTrashed(),
    'commentsThroughPosts' => [
        'posts' => fn ($join) => $join->as('posts_alias')->withTrashed(),
    ],
])->toSql();
```

Current output (using incorrect alias on the users table):
`... inner join "posts" as "posts_alias" on "posts_alias"."user_id" = "users"."id"`

Expected output (after checking the static cache for the alias on the far parent):
`... inner join "posts" as "posts_alias" on "posts_alias"."user_id" = "users_alias"."id"`

