### PR TITLE
Using alias from the 'from' method when set

### DIFF
--- a/src/JoinsHelper.php
+++ b/src/JoinsHelper.php
@@ -77,8 +77,16 @@ class JoinsHelper
             // If the model is already associated with another query, we need to clone the model.
             // This can happen if a certain query, *before having interacted with the library
             // `joinRelationship()` method*, was cloned by previous code.
+
+            // Preserve the from clause (including any alias) before setModel overwrites it
+            $originalFrom = $query->getQuery()->from;
+
             $query->setModel($model = new ($query->getModel()));
             $model->mergeCasts($originalModel->getCasts());
+
+            if ($originalFrom) {
+                $query->getQuery()->from = $originalFrom;
+            }
 
             // Link the Spl Object ID of the query to the new model...
             static::$modelQueryDictionary[$model] = $querySplObjectId;
@@ -99,9 +107,17 @@ class JoinsHelper
             $originalModel = $query->getModel();
             $originalJoinsHelper = JoinsHelper::make($originalModel);
 
+            // Preserve the from clause (including any alias) before setModel overwrites it
+            $originalFrom = $query->getQuery()->from;
+
             // Ensure the model of the cloned query is unique to the query.
             $query->setModel($model = new $originalModel());
             $model->mergeCasts($originalModel->getCasts());
+
+            // Restore the original from clause if it was set
+            if ($originalFrom) {
+                $query->getQuery()->from = $originalFrom;
+            }
 
             // Update any `beforeQueryCallbacks` to link to the new `$this` as Eloquent Query,
             // otherwise the reference to the current Eloquent query goes wrong. These query

--- a/tests/JoinRelationshipTest.php
+++ b/tests/JoinRelationshipTest.php
@@ -1016,7 +1016,7 @@ class JoinRelationshipTest extends TestCase
 
         // The join should reference the alias
         $this->assertQueryContains(
-            'inner join "users" on "users"."id" = "p"."user_id"',
+            'inner join "users" on "p"."user_id" = "users"."id"',
             $query
         );
     }
@@ -1042,7 +1042,7 @@ class JoinRelationshipTest extends TestCase
 
         // The second join should work normally
         $this->assertQueryContains(
-            'inner join "users" on "users"."id" = "comments"."user_id"',
+            'inner join "users" on "comments"."user_id" = "users"."id"',
             $query
         );
     }
@@ -1064,7 +1064,7 @@ class JoinRelationshipTest extends TestCase
 
         // The join should reference the alias
         $this->assertQueryContains(
-            'inner join "users" on "users"."id" = "p"."user_id"',
+            'inner join "users" on "p"."user_id" = "users"."id"',
             $query
         );
 


### PR DESCRIPTION
Closes #223 

This pull request introduces improvements to how table aliases are handled and preserved during join operations in Eloquent queries, specifically when using the `joinRelationship` method. The changes ensure that aliases defined in the main table's `from` clause are correctly maintained and referenced throughout join and nested join operations, preventing query errors and improving reliability. Additionally, targeted cache clearing for model aliases has been implemented to avoid unintended side effects.

**Alias handling and preservation:**

* The `joinRelationship` method now detects if the main table has an alias in its `from` clause and registers this alias for use in joins, ensuring that all generated SQL references the correct alias.
* When the model associated with a query is cloned, the original `from` clause (including any alias) is preserved and restored after the clone, maintaining the correct table alias throughout query manipulation. [[1]](diffhunk://#diff-e3a7de0009dd3c81f21fbaf52c854629d51fd9b4876af11b815cd995e68ad03bR80-R91) [[2]](diffhunk://#diff-e3a7de0009dd3c81f21fbaf52c854629d51fd9b4876af11b815cd995e68ad03bR111-R122)

**Cache management:**

* After performing a join with an alias, only the related model's alias is cleared from the cache, rather than clearing the entire cache, which prevents loss of unrelated alias information.
* Removed the previous blanket cache clearing after marking a relationship as joined, ensuring more precise cache management.

**Testing:**

* Added multiple tests to verify that table aliases are correctly preserved and referenced in various scenarios, including basic joins, nested relationships, and queries with selected columns and where clauses.