### PR TITLE
Add suport hyperf framework

### DIFF
--- a/src/PowerJoinsHyperfListener.php
+++ b/src/PowerJoinsHyperfListener.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kirschbaum\PowerJoins;
+
+use Hyperf\Event\Contract\ListenerInterface;
+use Kirschbaum\PowerJoins\EloquentJoins;
+use Psr\Container\ContainerInterface;
+use Hyperf\Database\Model\Booted;
+
+class PowerJoinListener implements ListenerInterface
+{
+    public function __construct(protected ContainerInterface $container) {}
+
+    public function listen(): array
+    {
+        return [
+            Booted::class,
+        ];
+    }
+
+    public function process(object $event): void
+    {
+        EloquentJoins::registerEloquentMacros();
+    }
+}


### PR DESCRIPTION
Add Hyperf Framework Support

What does this PR do?

Adds official support for [Hyperf](https://github.com/hyperf/hyperf), a high-performance coroutine PHP framework that uses Laravel's Eloquent ORM as its database component.

Why is this needed?
Hyperf implements Laravel's Eloquent with 100% compatibility, but doesn't use Laravel's ServiceProvider system. Currently, Hyperf users need to manually register PowerJoins macros, which is not obvious. This PR provides an official, documented way to use PowerJoins in Hyperf applications.

How to use in Hyperf:

Register a PowerJoinListener listener class in:

config\autoload\listeners.php

```
return [
     Kirschbaum\PowerJoins\PowerJoinListener::class
];
```


That's all, it's sufficient, and it will be functional in the hyperf framework.