### PR TITLE
Fix joinRelationship overriding columns in get()/first()

### DIFF
--- a/src/Mixins/JoinRelationship.php
+++ b/src/Mixins/JoinRelationship.php
@@ -116,9 +116,12 @@ class JoinRelationship
                 StaticCache::setTableAliasForModel($this->getModel(), $mainTableOrAlias);
             }
 
-            if (is_null($this->getSelect())) {
-                $this->select(sprintf('%s.*', $mainTableOrAlias));
-            }
+            $defaultSelect = sprintf('%s.*', $mainTableOrAlias);
+            $this->getQuery()->beforeQuery(function ($queryBuilder) use ($defaultSelect) {
+                if (is_null($queryBuilder->columns) || $queryBuilder->columns === ['*']) {
+                    $queryBuilder->columns = [$defaultSelect];
+                }
+            });
 
             if (Str::contains($relationName, '.')) {
                 $this->joinNestedRelationship($relationName, $callback, $joinType, $useAlias, $disableExtraConditions, $morphable);
@@ -399,6 +402,10 @@ class JoinRelationship
             }
 
             if ($aggregation) {
+                if (is_null($this->getSelect())) {
+                    $this->select(sprintf('%s.*', $this->getModel()->getTable()));
+                }
+
                 $aliasName = sprintf(
                     '%s_%s_%s',
                     $table,
@@ -530,9 +537,12 @@ class JoinRelationship
     public function powerJoinHas(): Closure
     {
         return function (string $relation, string $operator = '>=', int $count = 1, $boolean = 'and', Closure|array|string|null $callback = null, ?string $morphable = null): static {
-            if (is_null($this->getSelect())) {
-                $this->select(sprintf('%s.*', $this->getModel()->getTable()));
-            }
+            $defaultSelect = sprintf('%s.*', $this->getModel()->getTable());
+            $this->getQuery()->beforeQuery(function ($queryBuilder) use ($defaultSelect) {
+                if (is_null($queryBuilder->columns) || $queryBuilder->columns === ['*']) {
+                    $queryBuilder->columns = [$defaultSelect];
+                }
+            });
 
             if (is_null($this->getGroupBy())) {
                 $this->groupBy($this->getModel()->getQualifiedKeyName());

--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -431,6 +431,10 @@ class RelationshipsExtraMethods
     public function performHavingForEloquentPowerJoins()
     {
         return function ($builder, $operator, $count, ?string $morphable = null) {
+            if (is_null($builder->getSelect())) {
+                $builder->select(sprintf('%s.*', $builder->getModel()->getTable()));
+            }
+
             if ($morphable) {
                 $modelInstance = new $morphable();
 

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -205,9 +205,9 @@ class PowerJoinClause extends JoinClause
             $column($query);
 
             return $this->addNestedWhereQuery($query);
-        } else {
-            return parent::where($column, $operator, $value, $boolean);
         }
+
+        return parent::where($column, $operator, $value, $boolean);
     }
 
     /**

--- a/tests/JoinRelationshipTest.php
+++ b/tests/JoinRelationshipTest.php
@@ -3,6 +3,7 @@
 namespace Kirschbaum\PowerJoins\Tests;
 
 use Exception;
+use Illuminate\Support\Facades\DB;
 use Kirschbaum\PowerJoins\PowerJoinClause;
 use Kirschbaum\PowerJoins\Tests\Models\Category;
 use Kirschbaum\PowerJoins\Tests\Models\Comment;
@@ -541,6 +542,35 @@ class JoinRelationshipTest extends TestCase
 
         $this->assertQueryContains(
             'inner join "posts" on "posts"."user_id" = "users"."id"',
+            $query
+        );
+    }
+
+    /** @test */
+    public function test_join_relationship_respects_columns_defined_in_first()
+    {
+        $user = factory(User::class)->create();
+        factory(Post::class)->create([
+            'user_id' => $user->id,
+            'title' => 'Power Joins',
+        ]);
+
+        DB::enableQueryLog();
+        DB::flushQueryLog();
+
+        User::query()
+            ->joinRelationship('posts')
+            ->first(['posts.title as post_title']);
+
+        $query = collect(DB::getQueryLog())->last()['query'];
+
+        $this->assertQueryContains(
+            'select "posts"."title" as "post_title"',
+            $query
+        );
+
+        $this->assertQueryNotContains(
+            'select "users".* from "users"',
             $query
         );
     }


### PR DESCRIPTION
## Summary

- Defers the default `select('table.*')` in `joinRelationship()` and `powerJoinHas()` to a `beforeQuery` callback, so it only fires at query execution time when no explicit columns have been set
- This allows columns passed to `get()`/`first()` to take precedence via Laravel's `onceWithColumns` mechanism
- Adds explicit select guards in `orderByPowerJoins` and `performHavingForEloquentPowerJoins` which use `selectRaw` internally and need the base table columns present

Fixes #229

## Test plan

- [x] Existing failing test `test_join_relationship_respects_columns_defined_in_first` now passes
- [x] Full test suite passes (128 tests, 0 failures)
- [x] Verify `joinRelationship()->first(['specific_columns'])` returns only requested columns (covered by `test_join_relationship_respects_columns_defined_in_first`)
- [x] Verify `joinRelationship()->get()` still defaults to `select table.*` (covered by existing join tests)
- [x] Verify `orderByPowerJoinsCount/Sum/Avg` still includes model columns alongside aggregates (covered by `test_order_by_relationship_count/sum/avg/min_and_max`)