### PR TITLE
Add cross-connection join support

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,27 @@ Post::orderByLeftPowerJoinsMin('comments.votes');
 Post::orderByLeftPowerJoinsMax('comments.votes');
 ```
 
+### 4 - Joining relationships across database connections
+
+If your models live on different database connections, Eloquent Power Joins handles the cross-connection join automatically. All you need is to set the `$connection` property on each model as usual — no additional configuration is required.
+
+```php
+class Author extends Model
+{
+    protected $connection = 'primary';
+}
+
+class Article extends Model
+{
+    protected $connection = 'secondary';
+}
+```
+
+```php
+// Produces: ... inner join `secondary_db`.`articles` on `secondary_db`.`articles`.`author_id` = `authors`.`id`
+Author::joinRelationship('articles')->get();
+```
+
 ***
 
 ## Contributing

--- a/src/ConnectionAwareTable.php
+++ b/src/ConnectionAwareTable.php
@@ -17,13 +17,14 @@ use InvalidArgumentException;
  * For same-connection joins this class is a pass-through returning plain
  * strings — the base grammar handles quoting and prefixing as before. For
  * cross-connection joins it returns an Expression already quoted by the base
- * grammar, embedding the *related* connection's table prefix and database name
- * so the base grammar doesn't apply its own prefix on top.
+ * grammar, embedding the *related* connection's table prefix and qualified
+ * database/schema name so the base grammar doesn't apply its own prefix on
+ * top.
  *
- * Database name qualification (the "db.table" form) is applied automatically
- * for drivers that support it (MySQL/MariaDB). SQLite is excluded because it
- * requires ATTACH DATABASE for cross-database access and does not support the
- * simple database.table syntax.
+ * The qualifier used for "schema.table" form is sourced from the connection
+ * config's `schema` key first, falling back to the physical database name.
+ * SQLite is supported when the application has ATTACHed a database under an
+ * alias and set that alias as the connection's `schema`.
  */
 class ConnectionAwareTable
 {
@@ -171,20 +172,33 @@ class ConnectionAwareTable
     }
 
     /**
-     * Returns the database name to use as a qualifier, or null when qualification
-     * is not applicable (SQLite driver or empty name).
+     * Returns the database/schema name to use as a qualifier, or null when
+     * qualification is not applicable. Prefers the connection config's `schema`
+     * key (logical schema for PostgreSQL, ATTACH alias for SQLite) and falls
+     * back to the physical database name (MySQL/MariaDB).
      */
     public static function qualifiedDatabaseName(Model $model): ?string
     {
         $connection = $model->getConnection();
+        $config = $connection->getConfig();
 
+        $schema = $config['schema'] ?? null;
+
+        if (is_string($schema) && $schema !== '') {
+            return $schema;
+        }
+
+        // SQLite has no standalone database.table syntax; cross-database
+        // access requires ATTACH DATABASE with an alias set via `schema`.
+        // Without that alias, getDatabaseName() returns a file path or
+        // `:memory:`, which is not a valid qualifier.
         if ($connection->getDriverName() === 'sqlite') {
             return null;
         }
 
         $name = (string) $connection->getDatabaseName();
 
-        return empty($name) ? null : $name;
+        return $name === '' ? null : $name;
     }
 
     protected static function prefixed(Model $model, string $table): string

--- a/src/ConnectionAwareTable.php
+++ b/src/ConnectionAwareTable.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kirschbaum\PowerJoins;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Query\Expression;
+use InvalidArgumentException;
+
+/**
+ * Helper for building table/column references that stay correct when the
+ * related model lives on a different database connection from the base query.
+ *
+ * For same-connection joins this class is a pass-through returning plain
+ * strings — the base grammar handles quoting and prefixing as before. For
+ * cross-connection joins it returns an Expression already quoted by the base
+ * grammar, embedding the *related* connection's table prefix (and optionally
+ * the related database name) so the base grammar doesn't apply its own prefix
+ * on top.
+ */
+class ConnectionAwareTable
+{
+    /**
+     * Connection names whose joined references should be qualified with the
+     * database name ("db.table" form). Opt-in because it only works when both
+     * databases live on the same server.
+     *
+     * @var array<string, true>
+     */
+    protected static array $qualifyWithDatabase = [];
+
+    public static function qualifyWithDatabaseName(string $connectionName): void
+    {
+        static::$qualifyWithDatabase[$connectionName] = true;
+    }
+
+    public static function disableDatabaseQualification(string $connectionName): void
+    {
+        unset(static::$qualifyWithDatabase[$connectionName]);
+    }
+
+    public static function shouldQualifyWithDatabase(Model $related): bool
+    {
+        return isset(static::$qualifyWithDatabase[(string) $related->getConnectionName()]);
+    }
+
+    /**
+     * Whether the given model's connection differs from the base query's model connection.
+     */
+    public static function isCrossConnection(Model $owner, EloquentBuilder|QueryBuilder $baseQuery): bool
+    {
+        $baseModel = static::baseModel($baseQuery);
+
+        if (!$baseModel) {
+            return false;
+        }
+
+        return $owner->getConnectionName() !== $baseModel->getConnectionName();
+    }
+
+    /**
+     * Build the table argument for a join() call.
+     *
+     * Returns a plain string for same-connection joins (grammar handles prefix)
+     * or an Expression with the related connection's prefix baked in for
+     * cross-connection joins.
+     */
+    public static function tableReference(
+        Model $related,
+        EloquentBuilder|QueryBuilder $baseQuery,
+        ?string $alias = null,
+        ?string $tableName = null,
+    ): string|Expression {
+        $table = $tableName ?? $related->getTable();
+
+        if (!static::isCrossConnection($related, $baseQuery)) {
+            return $alias ? "{$table} as {$alias}" : $table;
+        }
+
+        $grammar = static::grammar($baseQuery);
+        $wrapped = $grammar->wrap(static::prefixed($related, $table));
+
+        if (static::shouldQualifyWithDatabase($related)) {
+            $wrapped = $grammar->wrap((string) $related->getConnection()->getDatabaseName()).'.'.$wrapped;
+        }
+
+        if ($alias) {
+            $wrapped .= ' as '.$grammar->wrap($alias);
+        }
+
+        return new Expression($wrapped);
+    }
+
+    /**
+     * Build a "table.column" reference that stays correct across connections.
+     *
+     * When an alias is given it takes precedence over the table name (aliases
+     * are unaffected by prefixing).
+     */
+    public static function columnReference(
+        Model $owner,
+        EloquentBuilder|QueryBuilder $baseQuery,
+        string $column,
+        ?string $alias = null,
+        ?string $tableName = null,
+    ): string|Expression {
+        if (!static::isCrossConnection($owner, $baseQuery)) {
+            $tableOrAlias = $alias ?: ($tableName ?? $owner->getTable());
+
+            return "{$tableOrAlias}.{$column}";
+        }
+
+        $grammar = static::grammar($baseQuery);
+
+        if ($alias) {
+            return new Expression($grammar->wrap($alias).'.'.$grammar->wrap($column));
+        }
+
+        $wrappedTable = $grammar->wrap(static::prefixed($owner, $tableName ?? $owner->getTable()));
+
+        if (static::shouldQualifyWithDatabase($owner)) {
+            $wrappedTable = $grammar->wrap((string) $owner->getConnection()->getDatabaseName()).'.'.$wrappedTable;
+        }
+
+        return new Expression($wrappedTable.'.'.$grammar->wrap($column));
+    }
+
+    /**
+     * Build a qualified column reference from a raw "table.col" string, using
+     * the context to detect which model the string refers to. Used when
+     * applying extra conditions from the related query.
+     */
+    /**
+     * Return either the registered alias or a connection-aware table reference.
+     */
+    public static function tableOrAliasReference(
+        Model $model,
+        EloquentBuilder|QueryBuilder $baseQuery,
+    ): string|Expression {
+        $cached = StaticCache::$powerJoinAliasesCache[spl_object_id($model)] ?? null;
+
+        if ($cached !== null && $cached !== $model->getTable()) {
+            if (!static::isCrossConnection($model, $baseQuery)) {
+                return $cached;
+            }
+
+            return new Expression(static::grammar($baseQuery)->wrap($cached));
+        }
+
+        return static::tableReference($model, $baseQuery);
+    }
+
+    /**
+     * Produce the column reference using either the registered alias (if any)
+     * or the qualified table form.
+     */
+    public static function columnOrAliasReference(
+        Model $model,
+        EloquentBuilder|QueryBuilder $baseQuery,
+        string $column,
+    ): string|Expression {
+        $cached = StaticCache::$powerJoinAliasesCache[spl_object_id($model)] ?? null;
+
+        if ($cached !== null && $cached !== $model->getTable()) {
+            return static::columnReference($model, $baseQuery, $column, $cached);
+        }
+
+        return static::columnReference($model, $baseQuery, $column);
+    }
+
+    public static function rewriteQualifiedColumn(
+        Model $owner,
+        EloquentBuilder|QueryBuilder $baseQuery,
+        string $columnWithTable,
+        ?string $alias = null,
+    ): string|Expression {
+        if (!str_contains($columnWithTable, '.')) {
+            return $columnWithTable;
+        }
+
+        [$tableOrAlias, $column] = explode('.', $columnWithTable, 2);
+
+        // Only rewrite if the string refers to the owner's table (or its alias).
+        if ($alias && $tableOrAlias === $alias) {
+            return static::columnReference($owner, $baseQuery, $column, $alias);
+        }
+
+        if ($tableOrAlias === $owner->getTable()) {
+            return static::columnReference($owner, $baseQuery, $column, $alias);
+        }
+
+        return $columnWithTable;
+    }
+
+    protected static function prefixed(Model $model, string $table): string
+    {
+        return (string) $model->getConnection()->getTablePrefix().$table;
+    }
+
+    protected static function baseModel(EloquentBuilder|QueryBuilder $query): ?Model
+    {
+        if ($query instanceof EloquentBuilder) {
+            return $query->getModel();
+        }
+
+        return null;
+    }
+
+    protected static function grammar(EloquentBuilder|QueryBuilder $query)
+    {
+        if ($query instanceof EloquentBuilder) {
+            return $query->getQuery()->getGrammar();
+        }
+
+        if ($query instanceof QueryBuilder) {
+            return $query->getGrammar();
+        }
+
+        throw new InvalidArgumentException('Unsupported query type: '.get_class($query));
+    }
+}

--- a/src/ConnectionAwareTable.php
+++ b/src/ConnectionAwareTable.php
@@ -83,8 +83,8 @@ class ConnectionAwareTable
         $grammar = static::grammar($baseQuery);
         $wrapped = $grammar->wrap(static::prefixed($related, $table));
 
-        if (static::shouldQualifyWithDatabase($related)) {
-            $wrapped = $grammar->wrap((string) $related->getConnection()->getDatabaseName()).'.'.$wrapped;
+        if ($dbName = static::qualifiedDatabaseName($related)) {
+            $wrapped = $grammar->wrap($dbName).'.'.$wrapped;
         }
 
         if ($alias) {
@@ -121,8 +121,8 @@ class ConnectionAwareTable
 
         $wrappedTable = $grammar->wrap(static::prefixed($owner, $tableName ?? $owner->getTable()));
 
-        if (static::shouldQualifyWithDatabase($owner)) {
-            $wrappedTable = $grammar->wrap((string) $owner->getConnection()->getDatabaseName()).'.'.$wrappedTable;
+        if ($dbName = static::qualifiedDatabaseName($owner)) {
+            $wrappedTable = $grammar->wrap($dbName).'.'.$wrappedTable;
         }
 
         return new Expression($wrappedTable.'.'.$grammar->wrap($column));
@@ -193,6 +193,17 @@ class ConnectionAwareTable
         }
 
         return $columnWithTable;
+    }
+
+    protected static function qualifiedDatabaseName(Model $model): ?string
+    {
+        if (!static::shouldQualifyWithDatabase($model)) {
+            return null;
+        }
+
+        $name = (string) $model->getConnection()->getDatabaseName();
+
+        return ($name === '' || $name === ':memory:') ? null : $name;
     }
 
     protected static function prefixed(Model $model, string $table): string

--- a/src/ConnectionAwareTable.php
+++ b/src/ConnectionAwareTable.php
@@ -17,36 +17,16 @@ use InvalidArgumentException;
  * For same-connection joins this class is a pass-through returning plain
  * strings — the base grammar handles quoting and prefixing as before. For
  * cross-connection joins it returns an Expression already quoted by the base
- * grammar, embedding the *related* connection's table prefix (and optionally
- * the related database name) so the base grammar doesn't apply its own prefix
- * on top.
+ * grammar, embedding the *related* connection's table prefix and database name
+ * so the base grammar doesn't apply its own prefix on top.
+ *
+ * Database name qualification (the "db.table" form) is applied automatically
+ * for drivers that support it (MySQL/MariaDB). SQLite is excluded because it
+ * requires ATTACH DATABASE for cross-database access and does not support the
+ * simple database.table syntax.
  */
 class ConnectionAwareTable
 {
-    /**
-     * Connection names whose joined references should be qualified with the
-     * database name ("db.table" form). Opt-in because it only works when both
-     * databases live on the same server.
-     *
-     * @var array<string, true>
-     */
-    protected static array $qualifyWithDatabase = [];
-
-    public static function qualifyWithDatabaseName(string $connectionName): void
-    {
-        static::$qualifyWithDatabase[$connectionName] = true;
-    }
-
-    public static function disableDatabaseQualification(string $connectionName): void
-    {
-        unset(static::$qualifyWithDatabase[$connectionName]);
-    }
-
-    public static function shouldQualifyWithDatabase(Model $related): bool
-    {
-        return isset(static::$qualifyWithDatabase[(string) $related->getConnectionName()]);
-    }
-
     /**
      * Whether the given model's connection differs from the base query's model connection.
      */
@@ -129,11 +109,6 @@ class ConnectionAwareTable
     }
 
     /**
-     * Build a qualified column reference from a raw "table.col" string, using
-     * the context to detect which model the string refers to. Used when
-     * applying extra conditions from the related query.
-     */
-    /**
      * Return either the registered alias or a connection-aware table reference.
      */
     public static function tableOrAliasReference(
@@ -195,15 +170,21 @@ class ConnectionAwareTable
         return $columnWithTable;
     }
 
-    protected static function qualifiedDatabaseName(Model $model): ?string
+    /**
+     * Returns the database name to use as a qualifier, or null when qualification
+     * is not applicable (SQLite driver or empty name).
+     */
+    public static function qualifiedDatabaseName(Model $model): ?string
     {
-        if (!static::shouldQualifyWithDatabase($model)) {
+        $connection = $model->getConnection();
+
+        if ($connection->getDriverName() === 'sqlite') {
             return null;
         }
 
-        $name = (string) $model->getConnection()->getDatabaseName();
+        $name = (string) $connection->getDatabaseName();
 
-        return ($name === '' || $name === ':memory:') ? null : $name;
+        return empty($name) ? null : $name;
     }
 
     protected static function prefixed(Model $model, string $table): string

--- a/src/Mixins/JoinRelationship.php
+++ b/src/Mixins/JoinRelationship.php
@@ -81,7 +81,7 @@ class JoinRelationship
 
     public function newPowerJoinClause(): Closure
     {
-        return function (QueryBuilder $parentQuery, string $type, string $table, ?Model $model = null) {
+        return function (QueryBuilder $parentQuery, string $type, $table, ?Model $model = null) {
             return new PowerJoinClause($parentQuery, $type, $table, $model);
         };
     }
@@ -429,7 +429,12 @@ class JoinRelationship
                     $this->orderBy($column, $direction);
                 } else {
                     $this->orderBy(
-                        sprintf('%s.%s', $table, $column),
+                        \Kirschbaum\PowerJoins\ConnectionAwareTable::columnReference(
+                            $latestRelationshipModel,
+                            $this,
+                            $column,
+                            $table !== $latestRelationshipModel->getTable() ? $table : null,
+                        ),
                         $direction
                     );
                 }

--- a/src/Mixins/JoinRelationship.php
+++ b/src/Mixins/JoinRelationship.php
@@ -420,11 +420,16 @@ class JoinRelationship
                     $table !== $latestRelationshipModel->getTable() ? $table : null,
                 );
 
+                $grammar = $this->getQuery()->getGrammar();
+                $columnSql = $columnRef instanceof Expression
+                    ? $columnRef->getValue($grammar)
+                    : $grammar->wrap($columnRef);
+
                 $this->selectRaw(
                     sprintf(
                         '%s(%s) as %s',
                         $aggregation,
-                        $columnRef instanceof Expression ? $columnRef->getValue($this->getQuery()->getGrammar()) : $columnRef,
+                        $columnSql,
                         $aliasName
                     )
                 )

--- a/src/Mixins/JoinRelationship.php
+++ b/src/Mixins/JoinRelationship.php
@@ -413,12 +413,18 @@ class JoinRelationship
                     $aggregation
                 );
 
+                $columnRef = \Kirschbaum\PowerJoins\ConnectionAwareTable::columnReference(
+                    $latestRelationshipModel,
+                    $this,
+                    $column,
+                    $table !== $latestRelationshipModel->getTable() ? $table : null,
+                );
+
                 $this->selectRaw(
                     sprintf(
-                        '%s(%s.%s) as %s',
+                        '%s(%s) as %s',
                         $aggregation,
-                        $table,
-                        $column,
+                        $columnRef instanceof Expression ? $columnRef->getValue($this->getQuery()->getGrammar()) : $columnRef,
                         $aliasName
                     )
                 )

--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -15,7 +15,9 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Database\MySqlConnection;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;
+use Kirschbaum\PowerJoins\ConnectionAwareTable;
 use Kirschbaum\PowerJoins\PowerJoinClause;
 use Kirschbaum\PowerJoins\StaticCache;
 
@@ -76,32 +78,35 @@ class RelationshipsExtraMethods
     protected function performJoinForEloquentPowerJoinsForBelongsTo()
     {
         return function ($query, $joinType, $callback = null, $alias = null, bool $disableExtraConditions = false) {
-            $joinedTable = $this->query->getModel()->getTable();
-            $parentTable = StaticCache::getTableOrAliasForModel($this->parent);
+            $relatedModel = $this->query->getModel();
+            $joinTable = ConnectionAwareTable::tableReference($relatedModel, $query);
+            $parentColumn = ConnectionAwareTable::columnOrAliasReference($this->parent, $query, $this->foreignKey);
 
-            $query->{$joinType}($joinedTable, function ($join) use ($callback, $joinedTable, $parentTable, $alias, $disableExtraConditions) {
+            $query->{$joinType}($joinTable, function ($join) use ($callback, $relatedModel, $parentColumn, $query, $alias, $disableExtraConditions) {
                 if ($alias) {
                     $join->as($alias);
                 }
 
                 $join->on(
-                    "{$parentTable}.{$this->foreignKey}",
+                    $parentColumn,
                     '=',
-                    "{$joinedTable}.{$this->ownerKey}"
+                    ConnectionAwareTable::columnReference($relatedModel, $query, $this->ownerKey, $alias),
                 );
 
                 if ($disableExtraConditions === false && $this->usesSoftDeletes($this->query->getScopes())) {
-                    $join->whereNull("{$joinedTable}.{$this->query->getModel()->getDeletedAtColumn()}");
+                    $join->whereNull(
+                        ConnectionAwareTable::columnReference($relatedModel, $query, $relatedModel->getDeletedAtColumn(), $alias)
+                    );
                 }
 
                 if ($disableExtraConditions === false) {
-                    $this->applyExtraConditions($join);
+                    $this->applyExtraConditions($join, $query, $relatedModel, $alias);
                 }
 
                 if ($callback && is_callable($callback)) {
                     $callback($join);
                 }
-            }, $this->query->getModel());
+            }, $relatedModel);
         };
     }
 
@@ -113,49 +118,55 @@ class RelationshipsExtraMethods
         return function ($builder, $joinType, $callback = null, $alias = null, bool $disableExtraConditions = false) {
             [$alias1, $alias2] = $alias;
 
-            $joinedTable = $alias1 ?: $this->getTable();
-            $parentTable = StaticCache::getTableOrAliasForModel($this->parent);
+            $related = $this->getModel();
+            $pivotTable = $this->getTable();
 
-            $builder->{$joinType}($this->getTable(), function ($join) use ($callback, $joinedTable, $parentTable, $alias1) {
+            $pivotTableArg = ConnectionAwareTable::tableReference($related, $builder, tableName: $pivotTable);
+            $parentColumn = ConnectionAwareTable::columnOrAliasReference($this->parent, $builder, $this->parentKey);
+
+            $builder->{$joinType}($pivotTableArg, function ($join) use ($callback, $related, $pivotTable, $parentColumn, $builder, $alias1) {
                 if ($alias1) {
                     $join->as($alias1);
                 }
 
                 $join->on(
-                    "{$joinedTable}.{$this->getForeignPivotKeyName()}",
+                    ConnectionAwareTable::columnReference($related, $builder, $this->getForeignPivotKeyName(), $alias1, $pivotTable),
                     '=',
-                    "{$parentTable}.{$this->parentKey}"
+                    $parentColumn,
                 );
 
-                if (is_array($callback) && isset($callback[$this->getTable()])) {
-                    $callback[$this->getTable()]($join);
+                if (is_array($callback) && isset($callback[$pivotTable])) {
+                    $callback[$pivotTable]($join);
                 }
             });
 
-            $builder->{$joinType}($this->getModel()->getTable(), function ($join) use ($callback, $joinedTable, $alias2, $disableExtraConditions) {
+            $relatedTableArg = ConnectionAwareTable::tableReference($related, $builder);
+
+            $builder->{$joinType}($relatedTableArg, function ($join) use ($callback, $related, $pivotTable, $builder, $alias1, $alias2, $disableExtraConditions) {
                 if ($alias2) {
                     $join->as($alias2);
                 }
 
                 $join->on(
-                    "{$this->getModel()->getTable()}.{$this->getRelatedKeyName()}",
+                    ConnectionAwareTable::columnReference($related, $builder, $this->getRelatedKeyName(), $alias2),
                     '=',
-                    "{$joinedTable}.{$this->getRelatedPivotKeyName()}"
+                    ConnectionAwareTable::columnReference($related, $builder, $this->getRelatedPivotKeyName(), $alias1, $pivotTable),
                 );
 
                 if ($disableExtraConditions === false && $this->usesSoftDeletes($this->query->getScopes())) {
-                    $join->whereNull($this->query->getModel()->getQualifiedDeletedAtColumn());
+                    $join->whereNull(
+                        ConnectionAwareTable::columnReference($related, $builder, $related->getDeletedAtColumn(), $alias2)
+                    );
                 }
 
-                // applying any extra conditions to the belongs to many relationship
                 if ($disableExtraConditions === false) {
-                    $this->applyExtraConditions($join);
+                    $this->applyExtraConditions($join, $builder, $related, $alias2);
                 }
 
-                if (is_array($callback) && isset($callback[$this->getModel()->getTable()])) {
-                    $callback[$this->getModel()->getTable()]($join);
+                if (is_array($callback) && isset($callback[$related->getTable()])) {
+                    $callback[$related->getTable()]($join);
                 }
-            }, $this->getModel());
+            }, $related);
 
             return $this;
         };
@@ -169,49 +180,55 @@ class RelationshipsExtraMethods
         return function ($builder, $joinType, $callback = null, $alias = null, bool $disableExtraConditions = false) {
             [$alias1, $alias2] = $alias;
 
-            $joinedTable = $alias1 ?: $this->getTable();
-            $parentTable = StaticCache::getTableOrAliasForModel($this->parent);
+            $related = $this->getModel();
+            $pivotTable = $this->getTable();
 
-            $builder->{$joinType}($this->getTable(), function ($join) use ($callback, $joinedTable, $parentTable, $alias1, $disableExtraConditions) {
+            $pivotTableArg = ConnectionAwareTable::tableReference($related, $builder, tableName: $pivotTable);
+            $parentColumn = ConnectionAwareTable::columnOrAliasReference($this->parent, $builder, $this->parentKey);
+
+            $builder->{$joinType}($pivotTableArg, function ($join) use ($callback, $related, $pivotTable, $parentColumn, $builder, $alias1, $disableExtraConditions) {
                 if ($alias1) {
                     $join->as($alias1);
                 }
 
                 $join->on(
-                    "{$joinedTable}.{$this->getForeignPivotKeyName()}",
+                    ConnectionAwareTable::columnReference($related, $builder, $this->getForeignPivotKeyName(), $alias1, $pivotTable),
                     '=',
-                    "{$parentTable}.{$this->parentKey}"
+                    $parentColumn,
                 );
 
-                // applying any extra conditions to the belongs to many relationship
                 if ($disableExtraConditions === false) {
-                    $this->applyExtraConditions($join);
+                    $this->applyExtraConditions($join, $builder, $related, $alias1, $pivotTable);
                 }
 
-                if (is_array($callback) && isset($callback[$this->getTable()])) {
-                    $callback[$this->getTable()]($join);
+                if (is_array($callback) && isset($callback[$pivotTable])) {
+                    $callback[$pivotTable]($join);
                 }
             });
 
-            $builder->{$joinType}($this->getModel()->getTable(), function ($join) use ($callback, $joinedTable, $alias2, $disableExtraConditions) {
+            $relatedTableArg = ConnectionAwareTable::tableReference($related, $builder);
+
+            $builder->{$joinType}($relatedTableArg, function ($join) use ($callback, $related, $pivotTable, $builder, $alias1, $alias2, $disableExtraConditions) {
                 if ($alias2) {
                     $join->as($alias2);
                 }
 
                 $join->on(
-                    "{$this->getModel()->getTable()}.{$this->getModel()->getKeyName()}",
+                    ConnectionAwareTable::columnReference($related, $builder, $related->getKeyName(), $alias2),
                     '=',
-                    "{$joinedTable}.{$this->getRelatedPivotKeyName()}"
+                    ConnectionAwareTable::columnReference($related, $builder, $this->getRelatedPivotKeyName(), $alias1, $pivotTable),
                 );
 
                 if ($disableExtraConditions === false && $this->usesSoftDeletes($this->query->getScopes())) {
-                    $join->whereNull($this->query->getModel()->getQualifiedDeletedAtColumn());
+                    $join->whereNull(
+                        ConnectionAwareTable::columnReference($related, $builder, $related->getDeletedAtColumn(), $alias2)
+                    );
                 }
 
-                if (is_array($callback) && isset($callback[$this->getModel()->getTable()])) {
-                    $callback[$this->getModel()->getTable()]($join);
+                if (is_array($callback) && isset($callback[$related->getTable()])) {
+                    $callback[$related->getTable()]($join);
                 }
-            }, $this->getModel());
+            }, $related);
 
             return $this;
         };
@@ -223,29 +240,38 @@ class RelationshipsExtraMethods
     protected function performJoinForEloquentPowerJoinsForMorph()
     {
         return function ($builder, $joinType, $callback = null, $alias = null, bool $disableExtraConditions = false) {
-            $builder->{$joinType}($this->getModel()->getTable(), function ($join) use ($callback, $disableExtraConditions, $alias) {
+            $related = $this->getModel();
+            $joinTable = ConnectionAwareTable::tableReference($related, $builder);
+
+            $builder->{$joinType}($joinTable, function ($join) use ($callback, $related, $builder, $disableExtraConditions, $alias) {
                 if ($alias) {
                     $join->as($alias);
                 }
 
                 $join->on(
-                    "{$this->getModel()->getTable()}.{$this->getForeignKeyName()}",
+                    ConnectionAwareTable::columnReference($related, $builder, $this->getForeignKeyName(), $alias),
                     '=',
-                    "{$this->parent->getTable()}.{$this->localKey}"
-                )->where("{$this->getModel()->getTable()}.{$this->getMorphType()}", '=', $this->getMorphClass());
+                    ConnectionAwareTable::columnOrAliasReference($this->parent, $builder, $this->localKey),
+                )->where(
+                    ConnectionAwareTable::columnReference($related, $builder, $this->getMorphType(), $alias),
+                    '=',
+                    $this->getMorphClass(),
+                );
 
                 if ($disableExtraConditions === false && $this->usesSoftDeletes($this->query->getScopes())) {
-                    $join->whereNull($this->query->getModel()->getQualifiedDeletedAtColumn());
+                    $join->whereNull(
+                        ConnectionAwareTable::columnReference($related, $builder, $related->getDeletedAtColumn(), $alias)
+                    );
                 }
 
                 if ($disableExtraConditions === false) {
-                    $this->applyExtraConditions($join);
+                    $this->applyExtraConditions($join, $builder, $related, $alias);
                 }
 
                 if ($callback && is_callable($callback)) {
                     $callback($join);
                 }
-            }, $this->getModel());
+            }, $related);
 
             return $this;
         };
@@ -259,20 +285,29 @@ class RelationshipsExtraMethods
         return function ($builder, $joinType, $callback = null, $alias = null, bool $disableExtraConditions = false, ?string $morphable = null) {
             /** @var Model */
             $modelInstance = new $morphable();
+            $related = $this->getModel();
 
-            $builder->{$joinType}($modelInstance->getTable(), function ($join) use ($modelInstance, $callback, $disableExtraConditions) {
+            $joinTable = ConnectionAwareTable::tableReference($modelInstance, $builder);
+
+            $builder->{$joinType}($joinTable, function ($join) use ($modelInstance, $related, $builder, $callback, $disableExtraConditions) {
                 $join->on(
-                    "{$this->getModel()->getTable()}.{$this->getForeignKeyName()}",
+                    ConnectionAwareTable::columnReference($related, $builder, $this->getForeignKeyName()),
                     '=',
-                    "{$modelInstance->getTable()}.{$modelInstance->getKeyName()}"
-                )->where("{$this->getModel()->getTable()}.{$this->getMorphType()}", '=', $modelInstance->getMorphClass());
+                    ConnectionAwareTable::columnReference($modelInstance, $builder, $modelInstance->getKeyName()),
+                )->where(
+                    ConnectionAwareTable::columnReference($related, $builder, $this->getMorphType()),
+                    '=',
+                    $modelInstance->getMorphClass(),
+                );
 
                 if ($disableExtraConditions === false && $this->usesSoftDeletes($modelInstance->getScopes())) {
-                    $join->whereNull($modelInstance->getQualifiedDeletedAtColumn());
+                    $join->whereNull(
+                        ConnectionAwareTable::columnReference($modelInstance, $builder, $modelInstance->getDeletedAtColumn())
+                    );
                 }
 
                 if ($disableExtraConditions === false) {
-                    $this->applyExtraConditions($join);
+                    $this->applyExtraConditions($join, $builder, $modelInstance);
                 }
 
                 if ($callback && is_callable($callback)) {
@@ -291,8 +326,7 @@ class RelationshipsExtraMethods
     {
         return function ($builder, $joinType, $callback = null, $alias = null, bool $disableExtraConditions = false, bool $hasCheck = false) {
             $joinedModel = $this->query->getModel();
-            $joinedTable = $alias ?: $joinedModel->getTable();
-            $parentTable = StaticCache::getTableOrAliasForModel($this->parent);
+            $parentTableOrAlias = StaticCache::getTableOrAliasForModel($this->parent);
             $isOneOfMany = method_exists($this, 'isOneOfMany') ? $this->isOneOfMany() : false;
 
             if ($isOneOfMany && !$hasCheck) {
@@ -300,8 +334,8 @@ class RelationshipsExtraMethods
                 $fkColumn = $this->getOneOfManySubQuery()->getQuery()->columns[1];
                 $localKey = $this->localKey;
 
-                $builder->where(function ($query) use ($column, $joinType, $joinedModel, $builder, $fkColumn, $parentTable, $localKey) {
-                    $query->whereIn($joinedModel->getQualifiedKeyName(), function ($query) use ($column, $joinedModel, $builder, $fkColumn, $parentTable, $localKey) {
+                $builder->where(function ($query) use ($column, $joinType, $joinedModel, $builder, $fkColumn, $parentTableOrAlias, $localKey) {
+                    $query->whereIn($joinedModel->getQualifiedKeyName(), function ($query) use ($column, $joinedModel, $builder, $fkColumn, $parentTableOrAlias, $localKey) {
                         $columnValue = $column->getValue($builder->getGrammar());
                         $direction = Str::contains($columnValue, 'min(') ? 'asc' : 'desc';
 
@@ -309,11 +343,11 @@ class RelationshipsExtraMethods
                         $columnName = Str::replace(['"', "'", '`'], '', $columnName);
 
                         if ($builder->getConnection() instanceof MySqlConnection) {
-                            $query->select('*')->from(function ($query) use ($joinedModel, $columnName, $fkColumn, $direction, $parentTable, $localKey) {
+                            $query->select('*')->from(function ($query) use ($joinedModel, $columnName, $fkColumn, $direction, $parentTableOrAlias, $localKey) {
                                 $query
                                     ->select($joinedModel->getQualifiedKeyName())
                                     ->from($joinedModel->getTable())
-                                    ->whereColumn($fkColumn, "{$parentTable}.{$localKey}")
+                                    ->whereColumn($fkColumn, "{$parentTableOrAlias}.{$localKey}")
                                     ->orderBy($columnName, $direction)
                                     ->take(1);
                             });
@@ -322,7 +356,7 @@ class RelationshipsExtraMethods
                                 ->select($joinedModel->getQualifiedKeyName())
                                 ->distinct($columnName)
                                 ->from($joinedModel->getTable())
-                                ->whereColumn($fkColumn, "{$parentTable}.{$localKey}")
+                                ->whereColumn($fkColumn, "{$parentTableOrAlias}.{$localKey}")
                                 ->orderBy($columnName, $direction)
                                 ->take(1);
                         }
@@ -334,31 +368,57 @@ class RelationshipsExtraMethods
                 });
             }
 
-            $builder->{$joinType}($this->query->getModel()->getTable(), function ($join) use ($callback, $joinedTable, $parentTable, $alias, $disableExtraConditions) {
+            $joinTable = ConnectionAwareTable::tableReference($joinedModel, $builder);
+            $foreignKeyColumn = $this->buildHasManyForeignKeyReference($joinedModel, $builder, $alias);
+
+            $builder->{$joinType}($joinTable, function ($join) use ($callback, $joinedModel, $foreignKeyColumn, $builder, $alias, $disableExtraConditions) {
                 if ($alias) {
                     $join->as($alias);
                 }
 
                 $join->on(
-                    $this->foreignKey,
+                    $foreignKeyColumn,
                     '=',
-                    "{$parentTable}.{$this->localKey}"
+                    ConnectionAwareTable::columnOrAliasReference($this->parent, $builder, $this->localKey),
                 );
 
                 if ($disableExtraConditions === false && $this->usesSoftDeletes($this->query->getScopes())) {
                     $join->whereNull(
-                        "{$joinedTable}.{$this->query->getModel()->getDeletedAtColumn()}"
+                        ConnectionAwareTable::columnReference($joinedModel, $builder, $joinedModel->getDeletedAtColumn(), $alias)
                     );
                 }
 
                 if ($disableExtraConditions === false) {
-                    $this->applyExtraConditions($join);
+                    $this->applyExtraConditions($join, $builder, $joinedModel, $alias);
                 }
 
                 if ($callback && is_callable($callback)) {
                     $callback($join);
                 }
-            }, $this->query->getModel());
+            }, $joinedModel);
+        };
+    }
+
+    /**
+     * Build the foreign key column reference for HasMany, handling the case
+     * where the foreign key may already be qualified ("table.col") upstream.
+     */
+    protected function buildHasManyForeignKeyReference()
+    {
+        return function (Model $joinedModel, $builder, ?string $alias = null) {
+            $foreignKey = $this->foreignKey;
+
+            if (str_contains($foreignKey, '.')) {
+                [$table, $column] = explode('.', $foreignKey, 2);
+
+                if ($table === $joinedModel->getTable()) {
+                    return ConnectionAwareTable::columnReference($joinedModel, $builder, $column, $alias);
+                }
+
+                return $foreignKey;
+            }
+
+            return ConnectionAwareTable::columnReference($joinedModel, $builder, $foreignKey, $alias);
         };
     }
 
@@ -369,57 +429,65 @@ class RelationshipsExtraMethods
     {
         return function ($builder, $joinType, $callback = null, $alias = null, bool $disableExtraConditions = false) {
             [$alias1, $alias2] = $alias;
-            $throughTable = $alias1 ?: $this->getThroughParent()->getTable();
-            $farTable = $alias2 ?: $this->getModel()->getTable();
 
-            $builder->{$joinType}($this->getThroughParent()->getTable(), function (PowerJoinClause $join) use ($callback, $throughTable, $alias1, $disableExtraConditions) {
+            $throughParent = $this->getThroughParent();
+            $farModel = $this->getModel();
+
+            $throughTableArg = ConnectionAwareTable::tableReference($throughParent, $builder);
+
+            $builder->{$joinType}($throughTableArg, function (PowerJoinClause $join) use ($callback, $throughParent, $builder, $alias1, $disableExtraConditions) {
                 if ($alias1) {
                     $join->as($alias1);
                 }
 
-                $farParentTable = StaticCache::getTableOrAliasForModel($this->getFarParent());
                 $join->on(
-                    "{$throughTable}.{$this->getFirstKeyName()}",
+                    ConnectionAwareTable::columnReference($throughParent, $builder, $this->getFirstKeyName(), $alias1),
                     '=',
-                    "{$farParentTable}.{$this->localKey}"
+                    ConnectionAwareTable::columnOrAliasReference($this->getFarParent(), $builder, $this->localKey),
                 );
 
-                if ($disableExtraConditions === false && $this->usesSoftDeletes($this->getThroughParent())) {
-                    $join->whereNull($this->getThroughParent()->getQualifiedDeletedAtColumn());
+                if ($disableExtraConditions === false && $this->usesSoftDeletes($throughParent)) {
+                    $join->whereNull(
+                        ConnectionAwareTable::columnReference($throughParent, $builder, $throughParent->getDeletedAtColumn(), $alias1)
+                    );
                 }
 
                 if ($disableExtraConditions === false) {
-                    $this->applyExtraConditions($join);
+                    $this->applyExtraConditions($join, $builder, $throughParent, $alias1);
                 }
 
-                if (is_array($callback) && isset($callback[$this->getThroughParent()->getTable()])) {
-                    $callback[$this->getThroughParent()->getTable()]($join);
+                if (is_array($callback) && isset($callback[$throughParent->getTable()])) {
+                    $callback[$throughParent->getTable()]($join);
                 }
 
                 if ($callback && is_callable($callback)) {
                     $callback($join);
                 }
-            }, $this->getThroughParent());
+            }, $throughParent);
 
-            $builder->{$joinType}($this->getModel()->getTable(), function (PowerJoinClause $join) use ($callback, $throughTable, $farTable, $alias2) {
+            $farTableArg = ConnectionAwareTable::tableReference($farModel, $builder);
+
+            $builder->{$joinType}($farTableArg, function (PowerJoinClause $join) use ($callback, $throughParent, $farModel, $builder, $alias1, $alias2) {
                 if ($alias2) {
                     $join->as($alias2);
                 }
 
                 $join->on(
-                    "{$farTable}.{$this->secondKey}",
+                    ConnectionAwareTable::columnReference($farModel, $builder, $this->secondKey, $alias2),
                     '=',
-                    "{$throughTable}.{$this->secondLocalKey}"
+                    ConnectionAwareTable::columnReference($throughParent, $builder, $this->secondLocalKey, $alias1),
                 );
 
                 if ($this->usesSoftDeletes($this->getScopes())) {
-                    $join->whereNull("{$farTable}.{$this->getModel()->getDeletedAtColumn()}");
+                    $join->whereNull(
+                        ConnectionAwareTable::columnReference($farModel, $builder, $farModel->getDeletedAtColumn(), $alias2)
+                    );
                 }
 
-                if (is_array($callback) && isset($callback[$this->getModel()->getTable()])) {
-                    $callback[$this->getModel()->getTable()]($join);
+                if (is_array($callback) && isset($callback[$farModel->getTable()])) {
+                    $callback[$farModel->getTable()]($join);
                 }
-            }, $this->getModel());
+            }, $farModel);
 
             return $this;
         };
@@ -435,17 +503,18 @@ class RelationshipsExtraMethods
                 $builder->select(sprintf('%s.*', $builder->getModel()->getTable()));
             }
 
-            if ($morphable) {
-                $modelInstance = new $morphable();
+            $target = $morphable ? new $morphable() : $this->query->getModel();
 
-                $builder
-                    ->selectRaw(sprintf('count(%s) as %s_count', $modelInstance->getQualifiedKeyName(), Str::replace('.', '_', $modelInstance->getTable())))
-                    ->havingRaw(sprintf('count(%s) %s %d', $modelInstance->getQualifiedKeyName(), $operator, $count));
-            } else {
-                $builder
-                    ->selectRaw(sprintf('count(%s) as %s_count', $this->query->getModel()->getQualifiedKeyName(), Str::replace('.', '_', $this->query->getModel()->getTable())))
-                    ->havingRaw(sprintf('count(%s) %s %d', $this->query->getModel()->getQualifiedKeyName(), $operator, $count));
-            }
+            $qualifiedKey = ConnectionAwareTable::columnReference($target, $builder, $target->getKeyName());
+            $countExpression = $qualifiedKey instanceof Expression
+                ? $qualifiedKey->getValue($builder->getQuery()->getGrammar())
+                : $qualifiedKey;
+
+            $countAlias = Str::replace('.', '_', $target->getTable()).'_count';
+
+            $builder
+                ->selectRaw(sprintf('count(%s) as %s', $countExpression, $countAlias))
+                ->havingRaw(sprintf('count(%s) %s %d', $countExpression, $operator, $count));
         };
     }
 
@@ -488,7 +557,10 @@ class RelationshipsExtraMethods
 
     public function applyExtraConditions()
     {
-        return function (PowerJoinClause $join) {
+        return function (PowerJoinClause $join, $baseQuery = null, ?Model $owner = null, ?string $alias = null, ?string $tableName = null) {
+            $baseQuery ??= $join;
+            $owner ??= $this->query->getModel();
+
             foreach ($this->getQuery()->getQuery()->wheres as $condition) {
                 if ($this->shouldNotApplyExtraCondition($condition)) {
                     continue;
@@ -499,41 +571,74 @@ class RelationshipsExtraMethods
                 }
 
                 $method = "apply{$condition['type']}Condition";
-                $this->$method($join, $condition);
+                $this->$method($join, $condition, $baseQuery, $owner, $alias, $tableName);
             }
         };
     }
 
     public function applyBasicCondition()
     {
-        return function ($join, $condition) {
-            $join->where($condition['column'], $condition['operator'], $condition['value'], $condition['boolean']);
+        return function ($join, $condition, $baseQuery = null, ?Model $owner = null, ?string $alias = null, ?string $tableName = null) {
+            $column = $this->rewriteExtraConditionColumn($condition['column'], $baseQuery, $owner, $alias, $tableName);
+            $join->where($column, $condition['operator'], $condition['value'], $condition['boolean']);
         };
     }
 
     public function applyNullCondition()
     {
-        return function ($join, $condition) {
-            $join->whereNull($condition['column'], $condition['boolean']);
+        return function ($join, $condition, $baseQuery = null, ?Model $owner = null, ?string $alias = null, ?string $tableName = null) {
+            $column = $this->rewriteExtraConditionColumn($condition['column'], $baseQuery, $owner, $alias, $tableName);
+            $join->whereNull($column, $condition['boolean']);
         };
     }
 
     public function applyNotNullCondition()
     {
-        return function ($join, $condition) {
-            $join->whereNotNull($condition['column'], $condition['boolean']);
+        return function ($join, $condition, $baseQuery = null, ?Model $owner = null, ?string $alias = null, ?string $tableName = null) {
+            $column = $this->rewriteExtraConditionColumn($condition['column'], $baseQuery, $owner, $alias, $tableName);
+            $join->whereNotNull($column, $condition['boolean']);
         };
     }
 
     public function applyNestedCondition()
     {
-        return function ($join, $condition) {
-            $join->where(function ($q) use ($condition) {
+        return function ($join, $condition, $baseQuery = null, ?Model $owner = null, ?string $alias = null, ?string $tableName = null) {
+            $join->where(function ($q) use ($condition, $baseQuery, $owner, $alias, $tableName) {
                 foreach ($condition['query']->wheres as $condition) {
                     $method = "apply{$condition['type']}Condition";
-                    $this->$method($q, $condition);
+                    $this->$method($q, $condition, $baseQuery, $owner, $alias, $tableName);
                 }
             });
+        };
+    }
+
+    /**
+     * Rewrite the column of an extra condition so it uses the related
+     * connection's prefix when the models live on different connections.
+     */
+    protected function rewriteExtraConditionColumn()
+    {
+        return function ($column, $baseQuery, ?Model $owner, ?string $alias, ?string $tableName) {
+            if (!is_string($column) || !$baseQuery || !$owner) {
+                return $column;
+            }
+
+            if (!str_contains($column, '.')) {
+                return $column;
+            }
+
+            [$tableOrAlias, $columnName] = explode('.', $column, 2);
+            $ownerTable = $tableName ?? $owner->getTable();
+
+            if ($tableOrAlias === $ownerTable) {
+                return ConnectionAwareTable::columnReference($owner, $baseQuery, $columnName, $alias, $tableName);
+            }
+
+            if ($alias && $tableOrAlias === $alias) {
+                return ConnectionAwareTable::columnReference($owner, $baseQuery, $columnName, $alias, $tableName);
+            }
+
+            return $column;
         };
     }
 

--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -506,9 +506,10 @@ class RelationshipsExtraMethods
             $target = $morphable ? new $morphable() : $this->query->getModel();
 
             $qualifiedKey = ConnectionAwareTable::columnReference($target, $builder, $target->getKeyName());
+            $grammar = $builder->getQuery()->getGrammar();
             $countExpression = $qualifiedKey instanceof Expression
-                ? $qualifiedKey->getValue($builder->getQuery()->getGrammar())
-                : $qualifiedKey;
+                ? $qualifiedKey->getValue($grammar)
+                : $grammar->wrap($qualifiedKey);
 
             $countAlias = Str::replace('.', '_', $target->getTable()).'_count';
 

--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -121,16 +121,16 @@ class RelationshipsExtraMethods
             $related = $this->getModel();
             $pivotTable = $this->getTable();
 
-            $pivotTableArg = ConnectionAwareTable::tableReference($related, $builder, tableName: $pivotTable);
+            $pivotTableArg = ConnectionAwareTable::tableReference($this->parent, $builder, tableName: $pivotTable);
             $parentColumn = ConnectionAwareTable::columnOrAliasReference($this->parent, $builder, $this->parentKey);
 
-            $builder->{$joinType}($pivotTableArg, function ($join) use ($callback, $related, $pivotTable, $parentColumn, $builder, $alias1) {
+            $builder->{$joinType}($pivotTableArg, function ($join) use ($callback, $pivotTable, $parentColumn, $builder, $alias1) {
                 if ($alias1) {
                     $join->as($alias1);
                 }
 
                 $join->on(
-                    ConnectionAwareTable::columnReference($related, $builder, $this->getForeignPivotKeyName(), $alias1, $pivotTable),
+                    ConnectionAwareTable::columnReference($this->parent, $builder, $this->getForeignPivotKeyName(), $alias1, $pivotTable),
                     '=',
                     $parentColumn,
                 );
@@ -150,7 +150,7 @@ class RelationshipsExtraMethods
                 $join->on(
                     ConnectionAwareTable::columnReference($related, $builder, $this->getRelatedKeyName(), $alias2),
                     '=',
-                    ConnectionAwareTable::columnReference($related, $builder, $this->getRelatedPivotKeyName(), $alias1, $pivotTable),
+                    ConnectionAwareTable::columnReference($this->parent, $builder, $this->getRelatedPivotKeyName(), $alias1, $pivotTable),
                 );
 
                 if ($disableExtraConditions === false && $this->usesSoftDeletes($this->query->getScopes())) {
@@ -183,22 +183,22 @@ class RelationshipsExtraMethods
             $related = $this->getModel();
             $pivotTable = $this->getTable();
 
-            $pivotTableArg = ConnectionAwareTable::tableReference($related, $builder, tableName: $pivotTable);
+            $pivotTableArg = ConnectionAwareTable::tableReference($this->parent, $builder, tableName: $pivotTable);
             $parentColumn = ConnectionAwareTable::columnOrAliasReference($this->parent, $builder, $this->parentKey);
 
-            $builder->{$joinType}($pivotTableArg, function ($join) use ($callback, $related, $pivotTable, $parentColumn, $builder, $alias1, $disableExtraConditions) {
+            $builder->{$joinType}($pivotTableArg, function ($join) use ($callback, $pivotTable, $parentColumn, $builder, $alias1, $disableExtraConditions) {
                 if ($alias1) {
                     $join->as($alias1);
                 }
 
                 $join->on(
-                    ConnectionAwareTable::columnReference($related, $builder, $this->getForeignPivotKeyName(), $alias1, $pivotTable),
+                    ConnectionAwareTable::columnReference($this->parent, $builder, $this->getForeignPivotKeyName(), $alias1, $pivotTable),
                     '=',
                     $parentColumn,
                 );
 
                 if ($disableExtraConditions === false) {
-                    $this->applyExtraConditions($join, $builder, $related, $alias1, $pivotTable);
+                    $this->applyExtraConditions($join, $builder, $this->parent, $alias1, $pivotTable);
                 }
 
                 if (is_array($callback) && isset($callback[$pivotTable])) {
@@ -216,7 +216,7 @@ class RelationshipsExtraMethods
                 $join->on(
                     ConnectionAwareTable::columnReference($related, $builder, $related->getKeyName(), $alias2),
                     '=',
-                    ConnectionAwareTable::columnReference($related, $builder, $this->getRelatedPivotKeyName(), $alias1, $pivotTable),
+                    ConnectionAwareTable::columnReference($this->parent, $builder, $this->getRelatedPivotKeyName(), $alias1, $pivotTable),
                 );
 
                 if ($disableExtraConditions === false && $this->usesSoftDeletes($this->query->getScopes())) {

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -39,12 +39,14 @@ class PowerJoinClause extends JoinClause
     /**
      * Create a new join clause instance.
      */
-    public function __construct(Builder $parentQuery, $type, string $table, ?Model $model = null)
+    public function __construct(Builder $parentQuery, $type, $table, ?Model $model = null)
     {
         parent::__construct($parentQuery, $type, $table);
 
         $this->model = $model;
-        $this->tableName = $table;
+        $this->tableName = $table instanceof \Illuminate\Database\Query\Expression
+            ? (string) $table->getValue($parentQuery->getGrammar())
+            : $table;
     }
 
     /**
@@ -54,7 +56,14 @@ class PowerJoinClause extends JoinClause
     {
         $this->alias = $alias;
         $this->joinedTableAlias = $joinedTableAlias;
-        $this->table = sprintf('%s as %s', $this->table, $alias);
+        if ($this->table instanceof \Illuminate\Database\Query\Expression) {
+            $grammar = $this->getGrammar();
+            $this->table = new \Illuminate\Database\Query\Expression(
+                $this->table->getValue($grammar).' as '.$grammar->wrap($alias)
+            );
+        } else {
+            $this->table = sprintf('%s as %s', $this->table, $alias);
+        }
         $this->useTableAliasInConditions();
 
         if ($this->model) {
@@ -118,7 +127,11 @@ class PowerJoinClause extends JoinClause
                 return true;
             }
 
-            if ($whereType === 'Null' && Str::contains($where['column'], $this->getModel()->getDeletedAtColumn())) {
+            $column = $where['column'] ?? '';
+            if ($column instanceof \Illuminate\Database\Query\Expression) {
+                $column = (string) $column->getValue($this->getGrammar());
+            }
+            if ($whereType === 'Null' && Str::contains($column, $this->getModel()->getDeletedAtColumn())) {
                 return true;
             }
 
@@ -142,6 +155,14 @@ class PowerJoinClause extends JoinClause
     {
         $key = $this->model->getKeyName();
         $table = $this->tableName;
+        $grammar = $this->getGrammar();
+
+        $where['first'] = $where['first'] instanceof \Illuminate\Database\Query\Expression
+            ? $where['first']->getValue($grammar)
+            : $where['first'];
+        $where['second'] = $where['second'] instanceof \Illuminate\Database\Query\Expression
+            ? $where['second']->getValue($grammar)
+            : $where['second'];
 
         // if it was already replaced, skip
         if (Str::startsWith($where['first'].'.', $this->alias.'.') || Str::startsWith($where['second'].'.', $this->alias.'.')) {
@@ -164,6 +185,10 @@ class PowerJoinClause extends JoinClause
     {
         $table = $this->tableName;
 
+        if ($where['column'] instanceof \Illuminate\Database\Query\Expression) {
+            $where['column'] = (string) $where['column']->getValue($this->getGrammar());
+        }
+
         if (Str::startsWith($where['column'].'.', $this->alias.'.')) {
             return $where;
         }
@@ -180,7 +205,7 @@ class PowerJoinClause extends JoinClause
 
     public function whereNull($columns, $boolean = 'and', $not = false)
     {
-        if ($this->alias && Str::contains($columns, $this->tableName)) {
+        if ($this->alias && is_string($columns) && Str::contains($columns, $this->tableName)) {
             $columns = str_replace("{$this->tableName}.", "{$this->alias}.", $columns);
         }
 
@@ -196,8 +221,27 @@ class PowerJoinClause extends JoinClause
     {
         if ($this->alias && is_string($column) && Str::contains($column, $this->tableName)) {
             $column = str_replace("{$this->tableName}.", "{$this->alias}.", $column);
-        } elseif ($this->alias && !is_callable($column)) {
+        } elseif ($this->alias && is_string($column) && Str::startsWith($column, $this->alias.'.')) {
+            // already prefixed
+        } elseif ($this->alias && !is_callable($column) && is_string($column)) {
             $column = $this->alias.'.'.$column;
+        } elseif (
+            !$this->alias
+            && is_string($column)
+            && $this->model
+            && Str::contains($column, $this->model->getTable().'.')
+            && $this->model->getConnectionName() !== $this->getConnection()->getName()
+        ) {
+            [$tableOrAlias, $columnName] = explode('.', $column, 2);
+            if ($tableOrAlias === $this->model->getTable()) {
+                $grammar = $this->getGrammar();
+                $prefixed = $this->model->getConnection()->getTablePrefix().$this->model->getTable();
+                $wrapped = $grammar->wrap($prefixed);
+                if (ConnectionAwareTable::shouldQualifyWithDatabase($this->model)) {
+                    $wrapped = $grammar->wrap((string) $this->model->getConnection()->getDatabaseName()).'.'.$wrapped;
+                }
+                $column = new \Illuminate\Database\Query\Expression($wrapped.'.'.$grammar->wrap($columnName));
+            }
         }
 
         if (is_callable($column)) {

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -230,7 +230,7 @@ class PowerJoinClause extends JoinClause
             && is_string($column)
             && $this->model
             && Str::contains($column, $this->model->getTable().'.')
-            && $this->model->getConnectionName() !== $this->getConnection()->getName()
+            && $this->model->getConnection()->getName() !== $this->getConnection()->getName()
         ) {
             [$tableOrAlias, $columnName] = explode('.', $column, 2);
             if ($tableOrAlias === $this->model->getTable()) {

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -127,10 +127,7 @@ class PowerJoinClause extends JoinClause
                 return true;
             }
 
-            $column = $where['column'] ?? '';
-            if ($column instanceof \Illuminate\Database\Query\Expression) {
-                $column = (string) $column->getValue($this->getGrammar());
-            }
+            $column = $this->resolveWhereColumn($where);
             if ($whereType === 'Null' && Str::contains($column, $this->getModel()->getDeletedAtColumn())) {
                 return true;
             }
@@ -203,6 +200,17 @@ class PowerJoinClause extends JoinClause
         return $where;
     }
 
+    protected function resolveWhereColumn(array $where): string
+    {
+        $column = $where['column'] ?? '';
+
+        if ($column instanceof \Illuminate\Database\Query\Expression) {
+            return (string) $column->getValue($this->getGrammar());
+        }
+
+        return (string) $column;
+    }
+
     public function whereNull($columns, $boolean = 'and', $not = false)
     {
         if ($this->alias && is_string($columns) && Str::contains($columns, $this->tableName)) {
@@ -264,7 +272,9 @@ class PowerJoinClause extends JoinClause
         }
 
         $this->wheres = array_filter($this->wheres, function ($where) {
-            if ($where['type'] === 'Null' && Str::contains($where['column'], $this->getModel()->getDeletedAtColumn())) {
+            $column = $this->resolveWhereColumn($where);
+
+            if ($where['type'] === 'Null' && Str::contains($column, $this->getModel()->getDeletedAtColumn())) {
                 return false;
             }
 
@@ -288,7 +298,9 @@ class PowerJoinClause extends JoinClause
         $hasCondition = null;
 
         $this->wheres = array_map(function ($where) use (&$hasCondition) {
-            if ($where['type'] === 'Null' && Str::contains($where['column'], $this->getModel()->getDeletedAtColumn())) {
+            $column = $this->resolveWhereColumn($where);
+
+            if ($where['type'] === 'Null' && Str::contains($column, $this->getModel()->getDeletedAtColumn())) {
                 $where['type'] = 'NotNull';
                 $hasCondition = true;
             }

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -213,8 +213,21 @@ class PowerJoinClause extends JoinClause
 
     public function whereNull($columns, $boolean = 'and', $not = false)
     {
-        if ($this->alias && is_string($columns) && Str::contains($columns, $this->tableName)) {
-            $columns = str_replace("{$this->tableName}.", "{$this->alias}.", $columns);
+        if ($this->alias) {
+            if (is_string($columns) && Str::contains($columns, $this->tableName)) {
+                $columns = str_replace("{$this->tableName}.", "{$this->alias}.", $columns);
+            } elseif ($columns instanceof \Illuminate\Database\Query\Expression) {
+                $grammar = $this->getGrammar();
+                $raw = (string) $columns->getValue($grammar);
+                $wrappedAlias = $grammar->wrap($this->alias);
+                $wrappedTable = $this->tableName;
+
+                if (Str::contains($raw, $wrappedTable)) {
+                    $columns = new \Illuminate\Database\Query\Expression(
+                        str_replace($wrappedTable, $wrappedAlias, $raw)
+                    );
+                }
+            }
         }
 
         return parent::whereNull($columns, $boolean, $not);
@@ -309,7 +322,19 @@ class PowerJoinClause extends JoinClause
         }, $this->wheres);
 
         if (!$hasCondition) {
-            $this->whereNotNull($this->getModel()->getQualifiedDeletedAtColumn());
+            $grammar = $this->getGrammar();
+            $deletedAtCol = $grammar->wrap($this->getModel()->getDeletedAtColumn());
+
+            if ($this->alias) {
+                $tableRef = $grammar->wrap($this->alias);
+            } elseif ($this->table instanceof \Illuminate\Database\Query\Expression) {
+                // Cross-connection: tableName is already grammar-wrapped with DB qualifier
+                $tableRef = $this->tableName;
+            } else {
+                $tableRef = $grammar->wrap($this->getModel()->getTable());
+            }
+
+            $this->whereNotNull(new \Illuminate\Database\Query\Expression("{$tableRef}.{$deletedAtCol}"));
         }
 
         return $this;

--- a/src/PowerJoinClause.php
+++ b/src/PowerJoinClause.php
@@ -237,8 +237,8 @@ class PowerJoinClause extends JoinClause
                 $grammar = $this->getGrammar();
                 $prefixed = $this->model->getConnection()->getTablePrefix().$this->model->getTable();
                 $wrapped = $grammar->wrap($prefixed);
-                if (ConnectionAwareTable::shouldQualifyWithDatabase($this->model)) {
-                    $wrapped = $grammar->wrap((string) $this->model->getConnection()->getDatabaseName()).'.'.$wrapped;
+                if ($dbName = ConnectionAwareTable::qualifiedDatabaseName($this->model)) {
+                    $wrapped = $grammar->wrap($dbName).'.'.$wrapped;
                 }
                 $column = new \Illuminate\Database\Query\Expression($wrapped.'.'.$grammar->wrap($columnName));
             }

--- a/tests/JoinRelationshipAcrossConnectionsTest.php
+++ b/tests/JoinRelationshipAcrossConnectionsTest.php
@@ -161,16 +161,18 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     */
 
     /** @test */
-    public function test_belongs_to_many_uses_related_connection_for_pivot_and_related_table()
+    public function test_belongs_to_many_uses_parent_connection_for_pivot_and_related_connection_for_related_table()
     {
         $query = Author::query()->joinRelationship('tags')->toSql();
 
+        // Pivot table uses parent's connection (same as base query, no DB qualifier needed)
         $this->assertQueryContains(
-            'inner join "secondary_db"."author_tag" on "secondary_db"."author_tag"."author_id" = "authors"."id"',
+            'inner join "author_tag" on "author_tag"."author_id" = "authors"."id"',
             $query
         );
+        // Related table uses related model's connection
         $this->assertQueryContains(
-            'inner join "secondary_db"."tags" on "secondary_db"."tags"."id" = "secondary_db"."author_tag"."tag_id"',
+            'inner join "secondary_db"."tags" on "secondary_db"."tags"."id" = "author_tag"."tag_id"',
             $query
         );
     }
@@ -187,21 +189,25 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     }
 
     /** @test */
-    public function test_morph_to_many_uses_related_connection_for_pivot_and_related_table()
+    public function test_morph_to_many_uses_parent_connection_for_pivot_and_related_connection_for_related_table()
     {
         $query = Author::query()->joinRelationship('labels')->toSql();
 
-        $this->assertQueryContains('"secondary_db"."labelables"', $query);
+        // Pivot table uses parent's connection (same as base query, no DB qualifier needed)
+        $this->assertQueryContains('"labelables"', $query);
+        $this->assertQueryNotContains('"secondary_db"."labelables"', $query);
+        // Related table uses related model's connection
         $this->assertQueryContains('"secondary_db"."labels"', $query);
     }
 
     /** @test */
-    public function test_morph_to_many_morph_type_condition_uses_correct_qualifier()
+    public function test_morph_to_many_morph_type_condition_uses_parent_qualifier()
     {
         $query = Author::query()->joinRelationship('labels')->toSql();
 
-        // The morph type discriminator on the pivot must also carry the database qualifier.
-        $this->assertQueryContains('"secondary_db"."labelables"."labelable_type"', $query);
+        // The morph type discriminator on the pivot uses parent's connection (no DB qualifier)
+        $this->assertQueryContains('"labelables"."labelable_type"', $query);
+        $this->assertQueryNotContains('"secondary_db"."labelables"."labelable_type"', $query);
     }
 
     /*
@@ -641,7 +647,9 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
             ->toSql();
 
         $this->assertQueryContains('"secondary_db"."articles"', $query);
-        $this->assertQueryContains('"secondary_db"."author_tag"', $query);
+        // Pivot uses parent's connection (same as base query, no DB qualifier)
+        $this->assertQueryContains('"author_tag"', $query);
+        $this->assertQueryNotContains('"secondary_db"."author_tag"', $query);
         $this->assertQueryContains('"secondary_db"."tags"', $query);
         $this->assertQueryContains('"secondary_db"."stickers"', $query);
     }
@@ -811,5 +819,168 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
             $query
         );
         $this->assertQueryNotContains('"secondary_db"."comments"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Soft Deletes — withTrashed/onlyTrashed via join callback
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_with_trashed_via_callback_on_cross_connection_belongs_to()
+    {
+        // Article (secondary) belongsTo Author (primary, SoftDeletes).
+        // The join adds a whereNull for deleted_at as an Expression.
+        // withTrashed() on the callback must remove it without crashing.
+        $query = Article::query()
+            ->leftJoinRelationship('author', fn ($join) => $join->withTrashed())
+            ->toSql();
+
+        $this->assertQueryContains(
+            'left join "primary_db"."authors" on "articles"."author_id" = "primary_db"."authors"."id"',
+            $query
+        );
+        // The joined model's deleted_at should be removed; base model's own WHERE deleted_at stays
+        $this->assertQueryNotContains('"primary_db"."authors"."deleted_at"', $query);
+    }
+
+    /** @test */
+    public function test_with_trashed_via_callback_on_cross_connection_has_many()
+    {
+        // Author (primary) hasMany Article (secondary, SoftDeletes).
+        $query = Author::query()
+            ->leftJoinRelationship('articles', fn ($join) => $join->withTrashed())
+            ->toSql();
+
+        $this->assertQueryContains(
+            'left join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
+            $query
+        );
+        // The joined model's deleted_at should be removed; base model's own WHERE deleted_at stays
+        $this->assertQueryNotContains('"secondary_db"."articles"."deleted_at"', $query);
+    }
+
+    /** @test */
+    public function test_only_trashed_via_callback_on_cross_connection_belongs_to()
+    {
+        // Article (secondary) belongsTo Author (primary, SoftDeletes).
+        // onlyTrashed() must flip whereNull to whereNotNull without crashing.
+        $query = Article::query()
+            ->joinRelationship('author', fn ($join) => $join->onlyTrashed())
+            ->toSql();
+
+        $this->assertQueryContains(
+            'inner join "primary_db"."authors" on "articles"."author_id" = "primary_db"."authors"."id"',
+            $query
+        );
+        $this->assertQueryContains('deleted_at', $query);
+        $this->assertQueryContains('is not null', $query);
+    }
+
+    /** @test */
+    public function test_only_trashed_via_callback_on_cross_connection_has_many()
+    {
+        $query = Author::query()
+            ->joinRelationship('articles', fn ($join) => $join->onlyTrashed())
+            ->toSql();
+
+        $this->assertQueryContains(
+            'inner join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
+            $query
+        );
+        $this->assertQueryContains('deleted_at', $query);
+        $this->assertQueryContains('is not null', $query);
+    }
+
+    /** @test */
+    public function test_with_trashed_via_callback_on_nested_cross_connection()
+    {
+        // Comment (secondary) -> Article (secondary) -> Author (primary, SoftDeletes)
+        $query = Comment::query()
+            ->leftJoinRelationship('article.author', [
+                'author' => fn ($join) => $join->withTrashed(),
+            ])
+            ->toSql();
+
+        $this->assertQueryContains(
+            'left join "articles" on "comments"."article_id" = "articles"."id"',
+            $query
+        );
+        $this->assertQueryContains(
+            'left join "primary_db"."authors" on "articles"."author_id" = "primary_db"."authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"authors"."deleted_at"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pivot table — qualification uses parent model's connection
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_belongs_to_many_pivot_uses_parent_connection_for_qualification()
+    {
+        // Author (primary) belongsToMany Tag (secondary) via author_tag.
+        // Pivot author_tag lives on primary (parent's DB), not secondary.
+        $query = Author::query()->joinRelationship('tags')->toSql();
+
+        // Pivot should use parent's DB (primary_db), not related's DB (secondary_db)
+        $this->assertQueryContains(
+            'inner join "author_tag" on "author_tag"."author_id" = "authors"."id"',
+            $query
+        );
+        // Related table should still use related's DB
+        $this->assertQueryContains('"secondary_db"."tags"', $query);
+    }
+
+    /** @test */
+    public function test_morph_to_many_pivot_uses_parent_connection_for_qualification()
+    {
+        // Author (primary) morphToMany Label (secondary) via labelables.
+        // Pivot should use parent's DB.
+        $query = Author::query()->joinRelationship('labels')->toSql();
+
+        // Pivot should not carry the related model's DB qualifier
+        $this->assertQueryContains('"labelables"', $query);
+        $this->assertQueryNotContains('"secondary_db"."labelables"', $query);
+        // Related table should still use related's DB
+        $this->assertQueryContains('"secondary_db"."labels"', $query);
+    }
+
+    /** @test */
+    public function test_power_join_where_has_on_belongs_to_many_cross_connection()
+    {
+        $query = Author::query()->powerJoinWhereHas('tags', function ($join) {
+            $join->where('tags.name', 'laravel');
+        })->toSql();
+
+        $this->assertQueryContains('"author_tag"', $query);
+        $this->assertQueryNotContains('"secondary_db"."author_tag"', $query);
+        $this->assertQueryContains('"secondary_db"."tags"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Aliases — combined with cross-connection soft deletes
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_alias_on_cross_connection_soft_delete_model()
+    {
+        // When combining alias + cross-DB + soft-delete, whereNull receives
+        // an Expression. The alias replacement must handle it.
+        $query = Article::query()
+            ->joinRelationship('author', fn ($join) => $join->as('author_alias'))
+            ->toSql();
+
+        $this->assertQueryContains('"primary_db"."authors" as "author_alias"', $query);
+        $this->assertQueryContains('"author_alias"."id"', $query);
+        // The deleted_at clause should use the alias, not the original table
+        $this->assertQueryContains('"author_alias"."deleted_at" is null', $query);
+        $this->assertQueryNotContains('"primary_db"."authors"."deleted_at"', $query);
     }
 }

--- a/tests/JoinRelationshipAcrossConnectionsTest.php
+++ b/tests/JoinRelationshipAcrossConnectionsTest.php
@@ -2,7 +2,6 @@
 
 namespace Kirschbaum\PowerJoins\Tests;
 
-use Kirschbaum\PowerJoins\ConnectionAwareTable;
 use Kirschbaum\PowerJoins\Tests\Models\CrossConnection\Article;
 use Kirschbaum\PowerJoins\Tests\Models\CrossConnection\Author;
 use Kirschbaum\PowerJoins\Tests\Models\CrossConnection\Comment;
@@ -15,12 +14,16 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         parent::defineEnvironment($app);
 
-        $app['config']->set('database.connections.testing.prefix', 'main_');
-
+        $app['config']->set('database.connections.primary', [
+            'driver' => 'mysql',
+            'database' => 'primary_db',
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ]);
         $app['config']->set('database.connections.secondary', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => 'sec_',
+            'driver' => 'mysql',
+            'database' => 'secondary_db',
+            'prefix' => '',
             'foreign_key_constraints' => false,
         ]);
     }
@@ -36,12 +39,12 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->joinRelationship('articles')->toSql();
 
-        $this->assertQueryContains('from "main_authors"', $query);
+        $this->assertQueryContains('from "authors"', $query);
         $this->assertQueryContains(
-            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
             $query
         );
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryNotContains('join "articles"', $query);
     }
 
     /** @test */
@@ -50,10 +53,9 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
         $query = Author::query()->leftJoinRelationship('articles')->toSql();
 
         $this->assertQueryContains(
-            'left join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'left join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
             $query
         );
-        $this->assertQueryNotContains('"main_articles"', $query);
     }
 
     /** @test */
@@ -62,10 +64,9 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
         $query = Author::query()->rightJoinRelationship('articles')->toSql();
 
         $this->assertQueryContains(
-            'right join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'right join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
             $query
         );
-        $this->assertQueryNotContains('"main_articles"', $query);
     }
 
     /** @test */
@@ -73,12 +74,12 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Article::query()->joinRelationship('author')->toSql();
 
-        $this->assertQueryContains('from "sec_articles"', $query);
+        $this->assertQueryContains('from "articles"', $query);
         $this->assertQueryContains(
-            'inner join "main_authors" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "primary_db"."authors" on "articles"."author_id" = "primary_db"."authors"."id"',
             $query
         );
-        $this->assertQueryNotContains('"sec_authors"', $query);
+        $this->assertQueryNotContains('"secondary_db"."authors"', $query);
     }
 
     /** @test */
@@ -87,10 +88,9 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
         $query = Author::query()->joinRelationship('profile')->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_profiles" on "sec_profiles"."author_id" = "main_authors"."id"',
+            'inner join "secondary_db"."profiles" on "secondary_db"."profiles"."author_id" = "authors"."id"',
             $query
         );
-        $this->assertQueryNotContains('"main_profiles"', $query);
     }
 
     /*
@@ -102,54 +102,56 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     /** @test */
     public function test_nested_has_many_across_connections()
     {
-        // Author (main_) -> articles (sec_) -> comments (sec_)
+        // Author (testing) -> articles (secondary_db) -> comments (secondary_db)
         $query = Author::query()->joinRelationship('articles.comments')->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
             $query
         );
         $this->assertQueryContains(
-            'inner join "sec_comments" on "sec_comments"."article_id" = "sec_articles"."id"',
+            'inner join "secondary_db"."comments" on "secondary_db"."comments"."article_id" = "secondary_db"."articles"."id"',
             $query
         );
-        $this->assertQueryNotContains('"main_articles"', $query);
-        $this->assertQueryNotContains('"main_comments"', $query);
     }
 
     /** @test */
     public function test_nested_belongs_to_across_connections()
     {
-        // Comment (sec_) -> article (sec_) -> author (main_)
+        // Comment (secondary_db) -> article (secondary_db) -> author (primary_db)
+        // Comment->Article is same-connection (no qualifier); Article->Author is cross-connection
+        // and primary is in qualifyWithDatabase, so authors is qualified with primary_db.
         $query = Comment::query()->joinRelationship('article.author')->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_articles" on "sec_comments"."article_id" = "sec_articles"."id"',
+            'inner join "articles" on "comments"."article_id" = "articles"."id"',
             $query
         );
         $this->assertQueryContains(
-            'inner join "main_authors" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "primary_db"."authors" on "articles"."author_id" = "primary_db"."authors"."id"',
             $query
         );
-        $this->assertQueryNotContains('"sec_authors"', $query);
+        $this->assertQueryNotContains('"secondary_db"."authors"', $query);
     }
 
     /** @test */
     public function test_nested_zig_zag_across_connections()
     {
-        // Profile (sec_) -> author (main_) -> articles (sec_)
+        // Profile (secondary_db) -> author (primary_db) -> articles (secondary_db)
+        // Cross-connection is measured from the base (Profile, secondary_db):
+        // Author is cross-connection and primary is qualified → primary_db.authors.
+        // Articles is same-connection as base (secondary_db) — no DB qualifier.
         $query = Profile::query()->joinRelationship('author.articles')->toSql();
 
         $this->assertQueryContains(
-            'inner join "main_authors" on "sec_profiles"."author_id" = "main_authors"."id"',
+            'inner join "primary_db"."authors" on "profiles"."author_id" = "primary_db"."authors"."id"',
             $query
         );
         $this->assertQueryContains(
-            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "articles" on "articles"."author_id" = "primary_db"."authors"."id"',
             $query
         );
-        $this->assertQueryNotContains('"sec_authors"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryNotContains('"secondary_db"."articles"', $query);
     }
 
     /*
@@ -164,15 +166,13 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
         $query = Author::query()->joinRelationship('tags')->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_author_tag" on "sec_author_tag"."author_id" = "main_authors"."id"',
+            'inner join "secondary_db"."author_tag" on "secondary_db"."author_tag"."author_id" = "authors"."id"',
             $query
         );
         $this->assertQueryContains(
-            'inner join "sec_tags" on "sec_tags"."id" = "sec_author_tag"."tag_id"',
+            'inner join "secondary_db"."tags" on "secondary_db"."tags"."id" = "secondary_db"."author_tag"."tag_id"',
             $query
         );
-        $this->assertQueryNotContains('"main_author_tag"', $query);
-        $this->assertQueryNotContains('"main_tags"', $query);
     }
 
     /** @test */
@@ -181,10 +181,9 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
         $query = Author::query()->joinRelationship('stickers')->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_stickers" on "sec_stickers"."stickerable_id" = "main_authors"."id"',
+            'inner join "secondary_db"."stickers" on "secondary_db"."stickers"."stickerable_id" = "authors"."id"',
             $query
         );
-        $this->assertQueryNotContains('"main_stickers"', $query);
     }
 
     /** @test */
@@ -192,10 +191,17 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->joinRelationship('labels')->toSql();
 
-        $this->assertQueryContains('"sec_labelables"', $query);
-        $this->assertQueryContains('"sec_labels"', $query);
-        $this->assertQueryNotContains('"main_labelables"', $query);
-        $this->assertQueryNotContains('"main_labels"', $query);
+        $this->assertQueryContains('"secondary_db"."labelables"', $query);
+        $this->assertQueryContains('"secondary_db"."labels"', $query);
+    }
+
+    /** @test */
+    public function test_morph_to_many_morph_type_condition_uses_correct_qualifier()
+    {
+        $query = Author::query()->joinRelationship('labels')->toSql();
+
+        // The morph type discriminator on the pivot must also carry the database qualifier.
+        $this->assertQueryContains('"secondary_db"."labelables"."labelable_type"', $query);
     }
 
     /*
@@ -207,24 +213,22 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     /** @test */
     public function test_has_many_through_uses_related_connection_for_through_and_far_tables()
     {
-        // Author (main_) hasManyThrough Comment (sec_) via Article (sec_)
+        // Author (testing) hasManyThrough Comment (secondary_db) via Article (secondary_db)
         $query = Author::query()->joinRelationship('commentsThroughArticles')->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
             $query
         );
         $this->assertQueryContains(
-            'inner join "sec_comments" on "sec_comments"."article_id" = "sec_articles"."id"',
+            'inner join "secondary_db"."comments" on "secondary_db"."comments"."article_id" = "secondary_db"."articles"."id"',
             $query
         );
-        $this->assertQueryNotContains('"main_articles"', $query);
-        $this->assertQueryNotContains('"main_comments"', $query);
     }
 
     /*
     |--------------------------------------------------------------------------
-    | Soft Deletes — deleted_at clauses must also use the correct prefix
+    | Soft Deletes — deleted_at clauses must also use the correct qualifier
     |--------------------------------------------------------------------------
     */
 
@@ -233,8 +237,7 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->joinRelationship('articles')->toSql();
 
-        $this->assertQueryContains('"sec_articles"."deleted_at" is null', $query);
-        $this->assertQueryNotContains('"main_articles"."deleted_at"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"."deleted_at" is null', $query);
     }
 
     /** @test */
@@ -242,10 +245,8 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Article::query()->joinRelationship('author')->toSql();
 
-        // Article is soft-deletable; base table deleted_at filter applies main "from" side (sec_articles)
-        // Author is soft-deletable; join-side deleted_at must use main_ prefix
-        $this->assertQueryContains('"main_authors"."deleted_at" is null', $query);
-        $this->assertQueryNotContains('"sec_authors"."deleted_at"', $query);
+        $this->assertQueryContains('"primary_db"."authors"."deleted_at" is null', $query);
+        $this->assertQueryNotContains('"secondary_db"."authors"."deleted_at"', $query);
     }
 
     /** @test */
@@ -254,10 +255,24 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
         $query = Author::query()->joinRelationship('articlesWithTrashed')->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
             $query
         );
-        $this->assertQueryNotContains('"sec_articles"."deleted_at"', $query);
+        $this->assertQueryNotContains('"secondary_db"."articles"."deleted_at"', $query);
+    }
+
+    /** @test */
+    public function test_belongs_to_with_trashed_cross_connection_does_not_add_deleted_at_clause()
+    {
+        // Inverse path: Article (secondary) belongsTo Author (primary) withTrashed.
+        // The primary_db qualifier must appear on the join but no deleted_at clause.
+        $query = Article::query()->joinRelationship('authorWithTrashed')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "primary_db"."authors" on "articles"."author_id" = "primary_db"."authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"primary_db"."authors"."deleted_at"', $query);
     }
 
     /*
@@ -272,11 +287,10 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
         $query = Author::query()->joinRelationship('publishedArticles')->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
             $query
         );
-        $this->assertQueryContains('"sec_articles"."published" = ?', $query);
-        $this->assertQueryNotContains('"main_articles"."published"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"."published" = ?', $query);
     }
 
     /** @test */
@@ -287,11 +301,10 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
         })->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
             $query
         );
-        $this->assertQueryContains('"sec_articles"."published"', $query);
-        $this->assertQueryNotContains('"main_articles"."published"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"."published"', $query);
     }
 
     /*
@@ -305,9 +318,8 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->joinRelationship('articles', fn ($join) => $join->as('a'))->toSql();
 
-        $this->assertQueryContains('"sec_articles" as "a"', $query);
-        $this->assertQueryContains('"a"."author_id" = "main_authors"."id"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles" as "a"', $query);
+        $this->assertQueryContains('"a"."author_id" = "authors"."id"', $query);
     }
 
     /** @test */
@@ -315,9 +327,7 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->joinRelationshipUsingAlias('articles')->toSql();
 
-        // The real table is sec_articles; alias is auto-generated
-        $this->assertQueryContains('"sec_articles" as', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles" as', $query);
     }
 
     /** @test */
@@ -325,8 +335,8 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->joinRelationship('articles', 'my_alias')->toSql();
 
-        $this->assertQueryContains('"sec_articles" as "my_alias"', $query);
-        $this->assertQueryContains('"my_alias"."author_id" = "main_authors"."id"', $query);
+        $this->assertQueryContains('"secondary_db"."articles" as "my_alias"', $query);
+        $this->assertQueryContains('"my_alias"."author_id" = "authors"."id"', $query);
     }
 
     /*
@@ -340,7 +350,7 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->joinRelationship('articles')->toSql();
 
-        $this->assertQueryContains('select "main_authors".* from "main_authors"', $query);
+        $this->assertQueryContains('select "authors".* from "authors"', $query);
     }
 
     /** @test */
@@ -348,7 +358,7 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Article::query()->joinRelationship('author')->toSql();
 
-        $this->assertQueryContains('select "sec_articles".* from "sec_articles"', $query);
+        $this->assertQueryContains('select "articles".* from "articles"', $query);
     }
 
     /*
@@ -362,8 +372,8 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->powerJoinHas('articles')->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
+        $this->assertQueryNotContains('join "articles"', $query);
     }
 
     /** @test */
@@ -373,8 +383,26 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
             $join->where('articles.published', true);
         })->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
+    }
+
+    /** @test */
+    public function test_scope_using_power_join_where_has_works_across_connections()
+    {
+        // scopeHasPublishedArticles calls powerJoinWhereHas internally.
+        $query = Author::query()->hasPublishedArticles()->toSql();
+
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"."published"', $query);
+    }
+
+    /** @test */
+    public function test_power_join_has_with_minimum_count_threshold_across_connections()
+    {
+        $query = Author::query()->powerJoinHas('articles', '>=', 2)->toSql();
+
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
+        $this->assertQueryNotContains('join "articles"', $query);
     }
 
     /** @test */
@@ -382,8 +410,7 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->powerJoinDoesntHave('articles')->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
     }
 
     /** @test */
@@ -391,10 +418,8 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->powerJoinWhereHas('articles.comments')->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryContains('"sec_comments"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
-        $this->assertQueryNotContains('"main_comments"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
+        $this->assertQueryContains('"secondary_db"."comments"', $query);
     }
 
     /*
@@ -408,8 +433,8 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->orderByPowerJoins('articles.id')->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
+        $this->assertQueryNotContains('join "articles"', $query);
     }
 
     /*
@@ -427,43 +452,10 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
             ->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
             $query,
             times: 1
         );
-    }
-
-    /*
-    |--------------------------------------------------------------------------
-    | qualifyWithDatabaseName opt-in
-    |--------------------------------------------------------------------------
-    */
-
-    /** @test */
-    public function test_qualify_with_database_name_prefixes_join_with_database()
-    {
-        ConnectionAwareTable::qualifyWithDatabaseName('secondary');
-
-        try {
-            $query = Author::query()->joinRelationship('articles')->toSql();
-
-            // sqlite :memory: returns ":memory:" as the database name
-            $this->assertQueryContains(':memory:"."sec_articles', $query);
-            $this->assertQueryContains(':memory:"."sec_articles"."author_id"', $query);
-        } finally {
-            ConnectionAwareTable::disableDatabaseQualification('secondary');
-        }
-    }
-
-    /** @test */
-    public function test_disable_database_qualification_removes_database_prefix()
-    {
-        ConnectionAwareTable::qualifyWithDatabaseName('secondary');
-        ConnectionAwareTable::disableDatabaseQualification('secondary');
-
-        $query = Author::query()->joinRelationship('articles')->toSql();
-
-        $this->assertQueryNotContains(':memory:"."sec_articles', $query);
     }
 
     /*
@@ -477,8 +469,7 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->orderByPowerJoinsCount('articles.id')->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
     }
 
     /** @test */
@@ -486,8 +477,7 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->orderByPowerJoinsSum('articles.id')->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
     }
 
     /** @test */
@@ -495,8 +485,7 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->orderByPowerJoinsAvg('articles.id')->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
     }
 
     /** @test */
@@ -504,8 +493,7 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->orderByPowerJoinsMin('articles.id')->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
     }
 
     /** @test */
@@ -513,8 +501,7 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->orderByPowerJoinsMax('articles.id')->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
     }
 
     /** @test */
@@ -522,8 +509,23 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->orderByLeftPowerJoins('articles.id')->toSql();
 
-        $this->assertQueryContains('left join "sec_articles"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('left join "secondary_db"."articles"', $query);
+    }
+
+    /** @test */
+    public function test_order_by_power_joins_three_level_nested_across_connections()
+    {
+        // Author (primary) -> articles (secondary_db) -> comments (secondary_db) -> id.
+        // Cross-connection is measured against the base (Author/primary), so BOTH
+        // articles and comments are cross-connection — both get the secondary_db qualifier.
+        $query = Author::query()->orderByPowerJoins('articles.comments.id')->toSql();
+
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
+        $this->assertQueryContains('"secondary_db"."comments"', $query);
+        $this->assertQueryContains(
+            'inner join "secondary_db"."comments" on "secondary_db"."comments"."article_id" = "secondary_db"."articles"."id"',
+            $query
+        );
     }
 
     /*
@@ -538,15 +540,13 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
         $query = Author::query()->joinNestedRelationship('articles.comments', joinType: 'powerJoin')->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
             $query
         );
         $this->assertQueryContains(
-            'inner join "sec_comments" on "sec_comments"."article_id" = "sec_articles"."id"',
+            'inner join "secondary_db"."comments" on "secondary_db"."comments"."article_id" = "secondary_db"."articles"."id"',
             $query
         );
-        $this->assertQueryNotContains('"main_articles"', $query);
-        $this->assertQueryNotContains('"main_comments"', $query);
     }
 
     /*
@@ -558,15 +558,32 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     /** @test */
     public function test_morph_to_uses_target_model_connection_prefix()
     {
+        // Sticker (secondary_db) -> Author (primary_db): primary is in qualifyWithDatabase,
+        // so authors is qualified with primary_db.
         $query = Sticker::query()
             ->joinRelationship('stickerable', morphable: Author::class)
             ->toSql();
 
         $this->assertQueryContains(
-            'inner join "main_authors" on "sec_stickers"."stickerable_id" = "main_authors"."id"',
+            'inner join "primary_db"."authors" on "stickers"."stickerable_id" = "primary_db"."authors"."id"',
             $query
         );
-        $this->assertQueryNotContains('"sec_authors"', $query);
+        $this->assertQueryNotContains('"secondary_db"."authors"', $query);
+    }
+
+    /** @test */
+    public function test_morph_to_same_connection_morphable_does_not_add_qualifier()
+    {
+        // Sticker (secondary_db) -> Article (secondary_db): same connection — no DB qualifier.
+        $query = Sticker::query()
+            ->joinRelationship('stickerable', morphable: Article::class)
+            ->toSql();
+
+        $this->assertQueryContains(
+            'inner join "articles" on "stickers"."stickerable_id" = "articles"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"secondary_db"."articles"', $query);
     }
 
     /*
@@ -581,11 +598,10 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
         $query = Author::query()->joinRelationship('articlesOnlyTrashed')->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
             $query
         );
-        $this->assertQueryContains('"sec_articles"."deleted_at" is not null', $query);
-        $this->assertQueryNotContains('"main_articles"."deleted_at"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"."deleted_at" is not null', $query);
     }
 
     /*
@@ -602,17 +618,17 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
             ->joinRelationship('comments')
             ->toSql();
 
-        $this->assertQueryContains('from "sec_articles"', $query);
+        $this->assertQueryContains('from "articles"', $query);
         $this->assertQueryContains(
-            'inner join "main_authors" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "primary_db"."authors" on "articles"."author_id" = "primary_db"."authors"."id"',
             $query
         );
         $this->assertQueryContains(
-            'inner join "sec_comments" on "sec_comments"."article_id" = "sec_articles"."id"',
+            'inner join "comments" on "comments"."article_id" = "articles"."id"',
             $query
         );
-        $this->assertQueryNotContains('"main_comments"', $query);
-        $this->assertQueryNotContains('"sec_authors"', $query);
+        $this->assertQueryNotContains('"secondary_db"."comments"', $query);
+        $this->assertQueryNotContains('"secondary_db"."authors"', $query);
     }
 
     /** @test */
@@ -624,13 +640,10 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
             ->joinRelationship('stickers')
             ->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryContains('"sec_author_tag"', $query);
-        $this->assertQueryContains('"sec_tags"', $query);
-        $this->assertQueryContains('"sec_stickers"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
-        $this->assertQueryNotContains('"main_tags"', $query);
-        $this->assertQueryNotContains('"main_stickers"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
+        $this->assertQueryContains('"secondary_db"."author_tag"', $query);
+        $this->assertQueryContains('"secondary_db"."tags"', $query);
+        $this->assertQueryContains('"secondary_db"."stickers"', $query);
     }
 
     /*
@@ -644,10 +657,19 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->powerJoinDoesntHave('articles.comments')->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryContains('"sec_comments"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
-        $this->assertQueryNotContains('"main_comments"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
+        $this->assertQueryContains('"secondary_db"."comments"', $query);
+    }
+
+    /** @test */
+    public function test_power_join_doesnt_have_morph_many_across_connections()
+    {
+        // MorphMany doesntHave: the morph type discriminator in the ON clause must
+        // also carry the database qualifier, not just the foreign key column.
+        $query = Author::query()->powerJoinDoesntHave('stickers')->toSql();
+
+        $this->assertQueryContains('"secondary_db"."stickers"', $query);
+        $this->assertQueryContains('"secondary_db"."stickers"."stickerable_type"', $query);
     }
 
     /** @test */
@@ -657,9 +679,8 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
             $join->where('articles.published', true);
         })->toSql();
 
-        $this->assertQueryContains('"sec_articles"', $query);
-        $this->assertQueryContains('"sec_articles"."published"', $query);
-        $this->assertQueryNotContains('"main_articles"."published"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles"."published"', $query);
     }
 
     /*
@@ -676,7 +697,7 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
         $query = Author::query()->joinRelationship('articles')->toSql();
 
         $this->assertQueryContains(
-            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            'inner join "secondary_db"."articles" on "secondary_db"."articles"."author_id" = "authors"."id"',
             $query
         );
         $this->assertQueryNotContains(' as "a"', $query);
@@ -696,11 +717,10 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
             ->joinRelationship('publishedArticles', fn ($join) => $join->as('p'))
             ->toSql();
 
-        $this->assertQueryContains('"sec_articles" as "p"', $query);
-        $this->assertQueryContains('"p"."author_id" = "main_authors"."id"', $query);
+        $this->assertQueryContains('"secondary_db"."articles" as "p"', $query);
+        $this->assertQueryContains('"p"."author_id" = "authors"."id"', $query);
         $this->assertQueryContains('"p"."published"', $query);
-        $this->assertQueryNotContains('"main_articles"."published"', $query);
-        $this->assertQueryNotContains('"sec_articles"."published"', $query);
+        $this->assertQueryNotContains('"secondary_db"."articles"."published"', $query);
     }
 
     /*
@@ -714,10 +734,8 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
     {
         $query = Author::query()->joinRelationshipUsingAlias('articles.comments')->toSql();
 
-        $this->assertQueryContains('"sec_articles" as', $query);
-        $this->assertQueryContains('"sec_comments" as', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
-        $this->assertQueryNotContains('"main_comments"', $query);
+        $this->assertQueryContains('"secondary_db"."articles" as', $query);
+        $this->assertQueryContains('"secondary_db"."comments" as', $query);
     }
 
     /*
@@ -735,28 +753,63 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
             ])
             ->toSql();
 
-        $this->assertQueryContains('"sec_articles" as "art"', $query);
-        $this->assertQueryContains('"art"."author_id" = "main_authors"."id"', $query);
-        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryContains('"secondary_db"."articles" as "art"', $query);
+        $this->assertQueryContains('"art"."author_id" = "authors"."id"', $query);
     }
 
     /*
     |--------------------------------------------------------------------------
-    | Regression: same-connection join must not wrap table in Expression
+    | Table prefix combined with database qualifier
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_connection_prefix_is_included_in_database_qualified_table_reference()
+    {
+        config(['database.connections.primary' => [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => 'pri_',
+            'foreign_key_constraints' => false,
+        ]]);
+        config(['database.connections.secondary' => [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => 'sec_',
+            'foreign_key_constraints' => false,
+        ]]);
+
+        $query = Author::query()->joinRelationship('articles')->toSql();
+
+        // On sqlite databases, the lib skips the DB qualifier and applies only the prefix if exists.
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_articles"."author_id" = "pri_authors"."id"',
+            $query
+        );
+
+        $this->assertQueryNotContains('join "articles" on', $query);
+        $this->assertQueryNotContains('":memory:"', $query);
+
+        $this->getEnvironmentSetUp(app());
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Regression: same-connection join must not be qualified
     |--------------------------------------------------------------------------
     */
 
     /** @test */
     public function test_same_connection_join_under_cross_connection_suite_still_works()
     {
-        // Article (sec_) -> comments (sec_) — both on the same connection.
+        // Article (secondary_db) -> comments (secondary_db) — same connection.
         $query = Article::query()->joinRelationship('comments')->toSql();
 
-        $this->assertQueryContains('from "sec_articles"', $query);
+        $this->assertQueryContains('from "articles"', $query);
         $this->assertQueryContains(
-            'inner join "sec_comments" on "sec_comments"."article_id" = "sec_articles"."id"',
+            'inner join "comments" on "comments"."article_id" = "articles"."id"',
             $query
         );
-        $this->assertQueryNotContains('"main_', $query);
+        $this->assertQueryNotContains('"secondary_db"."comments"', $query);
     }
 }

--- a/tests/JoinRelationshipAcrossConnectionsTest.php
+++ b/tests/JoinRelationshipAcrossConnectionsTest.php
@@ -1,0 +1,762 @@
+<?php
+
+namespace Kirschbaum\PowerJoins\Tests;
+
+use Kirschbaum\PowerJoins\ConnectionAwareTable;
+use Kirschbaum\PowerJoins\Tests\Models\CrossConnection\Article;
+use Kirschbaum\PowerJoins\Tests\Models\CrossConnection\Author;
+use Kirschbaum\PowerJoins\Tests\Models\CrossConnection\Comment;
+use Kirschbaum\PowerJoins\Tests\Models\CrossConnection\Profile;
+use Kirschbaum\PowerJoins\Tests\Models\CrossConnection\Sticker;
+
+class JoinRelationshipAcrossConnectionsTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::defineEnvironment($app);
+
+        $app['config']->set('database.connections.testing.prefix', 'main_');
+
+        $app['config']->set('database.connections.secondary', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => 'sec_',
+            'foreign_key_constraints' => false,
+        ]);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Basic join types — HasMany / BelongsTo / HasOne
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_inner_join_has_many_uses_related_model_connection_prefix()
+    {
+        $query = Author::query()->joinRelationship('articles')->toSql();
+
+        $this->assertQueryContains('from "main_authors"', $query);
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_left_join_has_many_uses_related_model_connection_prefix()
+    {
+        $query = Author::query()->leftJoinRelationship('articles')->toSql();
+
+        $this->assertQueryContains(
+            'left join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_right_join_has_many_uses_related_model_connection_prefix()
+    {
+        $query = Author::query()->rightJoinRelationship('articles')->toSql();
+
+        $this->assertQueryContains(
+            'right join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_belongs_to_uses_related_model_connection_prefix()
+    {
+        $query = Article::query()->joinRelationship('author')->toSql();
+
+        $this->assertQueryContains('from "sec_articles"', $query);
+        $this->assertQueryContains(
+            'inner join "main_authors" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"sec_authors"', $query);
+    }
+
+    /** @test */
+    public function test_has_one_uses_related_model_connection_prefix()
+    {
+        $query = Author::query()->joinRelationship('profile')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_profiles" on "sec_profiles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"main_profiles"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Nested relationships (cross-connection at multiple levels)
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_nested_has_many_across_connections()
+    {
+        // Author (main_) -> articles (sec_) -> comments (sec_)
+        $query = Author::query()->joinRelationship('articles.comments')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryContains(
+            'inner join "sec_comments" on "sec_comments"."article_id" = "sec_articles"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryNotContains('"main_comments"', $query);
+    }
+
+    /** @test */
+    public function test_nested_belongs_to_across_connections()
+    {
+        // Comment (sec_) -> article (sec_) -> author (main_)
+        $query = Comment::query()->joinRelationship('article.author')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_comments"."article_id" = "sec_articles"."id"',
+            $query
+        );
+        $this->assertQueryContains(
+            'inner join "main_authors" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"sec_authors"', $query);
+    }
+
+    /** @test */
+    public function test_nested_zig_zag_across_connections()
+    {
+        // Profile (sec_) -> author (main_) -> articles (sec_)
+        $query = Profile::query()->joinRelationship('author.articles')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "main_authors" on "sec_profiles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"sec_authors"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | BelongsToMany / MorphMany / MorphToMany
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_belongs_to_many_uses_related_connection_for_pivot_and_related_table()
+    {
+        $query = Author::query()->joinRelationship('tags')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_author_tag" on "sec_author_tag"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryContains(
+            'inner join "sec_tags" on "sec_tags"."id" = "sec_author_tag"."tag_id"',
+            $query
+        );
+        $this->assertQueryNotContains('"main_author_tag"', $query);
+        $this->assertQueryNotContains('"main_tags"', $query);
+    }
+
+    /** @test */
+    public function test_morph_many_uses_related_model_connection_prefix()
+    {
+        $query = Author::query()->joinRelationship('stickers')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_stickers" on "sec_stickers"."stickerable_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"main_stickers"', $query);
+    }
+
+    /** @test */
+    public function test_morph_to_many_uses_related_connection_for_pivot_and_related_table()
+    {
+        $query = Author::query()->joinRelationship('labels')->toSql();
+
+        $this->assertQueryContains('"sec_labelables"', $query);
+        $this->assertQueryContains('"sec_labels"', $query);
+        $this->assertQueryNotContains('"main_labelables"', $query);
+        $this->assertQueryNotContains('"main_labels"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | HasManyThrough
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_has_many_through_uses_related_connection_for_through_and_far_tables()
+    {
+        // Author (main_) hasManyThrough Comment (sec_) via Article (sec_)
+        $query = Author::query()->joinRelationship('commentsThroughArticles')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryContains(
+            'inner join "sec_comments" on "sec_comments"."article_id" = "sec_articles"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryNotContains('"main_comments"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Soft Deletes — deleted_at clauses must also use the correct prefix
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_soft_deletes_deleted_at_clause_uses_related_connection_prefix()
+    {
+        $query = Author::query()->joinRelationship('articles')->toSql();
+
+        $this->assertQueryContains('"sec_articles"."deleted_at" is null', $query);
+        $this->assertQueryNotContains('"main_articles"."deleted_at"', $query);
+    }
+
+    /** @test */
+    public function test_soft_deletes_base_model_uses_its_own_connection_prefix()
+    {
+        $query = Article::query()->joinRelationship('author')->toSql();
+
+        // Article is soft-deletable; base table deleted_at filter applies main "from" side (sec_articles)
+        // Author is soft-deletable; join-side deleted_at must use main_ prefix
+        $this->assertQueryContains('"main_authors"."deleted_at" is null', $query);
+        $this->assertQueryNotContains('"sec_authors"."deleted_at"', $query);
+    }
+
+    /** @test */
+    public function test_with_trashed_relationship_does_not_add_deleted_at_clause()
+    {
+        $query = Author::query()->joinRelationship('articlesWithTrashed')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"sec_articles"."deleted_at"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Extra conditions / scopes
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_extra_where_conditions_on_related_use_correct_prefix()
+    {
+        $query = Author::query()->joinRelationship('publishedArticles')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryContains('"sec_articles"."published" = ?', $query);
+        $this->assertQueryNotContains('"main_articles"."published"', $query);
+    }
+
+    /** @test */
+    public function test_callback_closure_on_join_uses_correct_prefix()
+    {
+        $query = Author::query()->joinRelationship('articles', function ($join) {
+            $join->where('articles.published', true);
+        })->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryContains('"sec_articles"."published"', $query);
+        $this->assertQueryNotContains('"main_articles"."published"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Aliases
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_join_with_alias_still_uses_related_connection_for_real_table()
+    {
+        $query = Author::query()->joinRelationship('articles', fn ($join) => $join->as('a'))->toSql();
+
+        $this->assertQueryContains('"sec_articles" as "a"', $query);
+        $this->assertQueryContains('"a"."author_id" = "main_authors"."id"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_join_relationship_using_alias_helper_uses_related_connection()
+    {
+        $query = Author::query()->joinRelationshipUsingAlias('articles')->toSql();
+
+        // The real table is sec_articles; alias is auto-generated
+        $this->assertQueryContains('"sec_articles" as', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_join_relationship_using_provided_alias_as_string()
+    {
+        $query = Author::query()->joinRelationship('articles', 'my_alias')->toSql();
+
+        $this->assertQueryContains('"sec_articles" as "my_alias"', $query);
+        $this->assertQueryContains('"my_alias"."author_id" = "main_authors"."id"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto-included select and column references
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_auto_select_statement_uses_base_model_connection_prefix()
+    {
+        $query = Author::query()->joinRelationship('articles')->toSql();
+
+        $this->assertQueryContains('select "main_authors".* from "main_authors"', $query);
+    }
+
+    /** @test */
+    public function test_auto_select_from_secondary_connection_base_uses_its_prefix()
+    {
+        $query = Article::query()->joinRelationship('author')->toSql();
+
+        $this->assertQueryContains('select "sec_articles".* from "sec_articles"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | powerJoinHas / powerJoinWhereHas / powerJoinDoesntHave
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_power_join_has_across_connections()
+    {
+        $query = Author::query()->powerJoinHas('articles')->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_power_join_where_has_across_connections()
+    {
+        $query = Author::query()->powerJoinWhereHas('articles', function ($join) {
+            $join->where('articles.published', true);
+        })->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_power_join_doesnt_have_across_connections()
+    {
+        $query = Author::query()->powerJoinDoesntHave('articles')->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_power_join_where_has_nested_across_connections()
+    {
+        $query = Author::query()->powerJoinWhereHas('articles.comments')->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryContains('"sec_comments"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryNotContains('"main_comments"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | orderBy via joined relationship
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_order_by_power_join_across_connections()
+    {
+        $query = Author::query()->orderByPowerJoins('articles.id')->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Safety: the same relationship is not joined twice (regression guard)
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_does_not_join_same_cross_connection_relationship_twice()
+    {
+        $query = Author::query()
+            ->joinRelationship('articles')
+            ->joinRelationship('articles')
+            ->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query,
+            times: 1
+        );
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | qualifyWithDatabaseName opt-in
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_qualify_with_database_name_prefixes_join_with_database()
+    {
+        ConnectionAwareTable::qualifyWithDatabaseName('secondary');
+
+        try {
+            $query = Author::query()->joinRelationship('articles')->toSql();
+
+            // sqlite :memory: returns ":memory:" as the database name
+            $this->assertQueryContains(':memory:"."sec_articles', $query);
+            $this->assertQueryContains(':memory:"."sec_articles"."author_id"', $query);
+        } finally {
+            ConnectionAwareTable::disableDatabaseQualification('secondary');
+        }
+    }
+
+    /** @test */
+    public function test_disable_database_qualification_removes_database_prefix()
+    {
+        ConnectionAwareTable::qualifyWithDatabaseName('secondary');
+        ConnectionAwareTable::disableDatabaseQualification('secondary');
+
+        $query = Author::query()->joinRelationship('articles')->toSql();
+
+        $this->assertQueryNotContains(':memory:"."sec_articles', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | orderByPowerJoins aggregations
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_order_by_power_joins_count_across_connections()
+    {
+        $query = Author::query()->orderByPowerJoinsCount('articles.id')->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_order_by_power_joins_sum_across_connections()
+    {
+        $query = Author::query()->orderByPowerJoinsSum('articles.id')->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_order_by_power_joins_avg_across_connections()
+    {
+        $query = Author::query()->orderByPowerJoinsAvg('articles.id')->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_order_by_power_joins_min_across_connections()
+    {
+        $query = Author::query()->orderByPowerJoinsMin('articles.id')->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_order_by_power_joins_max_across_connections()
+    {
+        $query = Author::query()->orderByPowerJoinsMax('articles.id')->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /** @test */
+    public function test_order_by_left_power_joins_across_connections()
+    {
+        $query = Author::query()->orderByLeftPowerJoins('articles.id')->toSql();
+
+        $this->assertQueryContains('left join "sec_articles"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | joinNestedRelationship direct API
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_join_nested_relationship_direct_api_across_connections()
+    {
+        $query = Author::query()->joinNestedRelationship('articles.comments', joinType: 'powerJoin')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryContains(
+            'inner join "sec_comments" on "sec_comments"."article_id" = "sec_articles"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryNotContains('"main_comments"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | MorphTo cross-connection
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_morph_to_uses_target_model_connection_prefix()
+    {
+        $query = Sticker::query()
+            ->joinRelationship('stickerable', morphable: Author::class)
+            ->toSql();
+
+        $this->assertQueryContains(
+            'inner join "main_authors" on "sec_stickers"."stickerable_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"sec_authors"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | onlyTrashed on cross-connection join side
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_only_trashed_cross_connection_uses_related_prefix()
+    {
+        $query = Author::query()->joinRelationship('articlesOnlyTrashed')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryContains('"sec_articles"."deleted_at" is not null', $query);
+        $this->assertQueryNotContains('"main_articles"."deleted_at"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Mixed same-connection and cross-connection joins
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_mixed_same_and_cross_connection_joins_in_one_query()
+    {
+        $query = Article::query()
+            ->joinRelationship('author')
+            ->joinRelationship('comments')
+            ->toSql();
+
+        $this->assertQueryContains('from "sec_articles"', $query);
+        $this->assertQueryContains(
+            'inner join "main_authors" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryContains(
+            'inner join "sec_comments" on "sec_comments"."article_id" = "sec_articles"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"main_comments"', $query);
+        $this->assertQueryNotContains('"sec_authors"', $query);
+    }
+
+    /** @test */
+    public function test_multiple_cross_connection_siblings_in_one_query()
+    {
+        $query = Author::query()
+            ->joinRelationship('articles')
+            ->joinRelationship('tags')
+            ->joinRelationship('stickers')
+            ->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryContains('"sec_author_tag"', $query);
+        $this->assertQueryContains('"sec_tags"', $query);
+        $this->assertQueryContains('"sec_stickers"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryNotContains('"main_tags"', $query);
+        $this->assertQueryNotContains('"main_stickers"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | powerJoinDoesntHave nested and powerJoinHas with callback
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_power_join_doesnt_have_nested_across_connections()
+    {
+        $query = Author::query()->powerJoinDoesntHave('articles.comments')->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryContains('"sec_comments"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryNotContains('"main_comments"', $query);
+    }
+
+    /** @test */
+    public function test_power_join_has_with_callback_uses_correct_prefix()
+    {
+        $query = Author::query()->powerJoinHas('articles', '>=', 1, 'and', function ($join) {
+            $join->where('articles.published', true);
+        })->toSql();
+
+        $this->assertQueryContains('"sec_articles"', $query);
+        $this->assertQueryContains('"sec_articles"."published"', $query);
+        $this->assertQueryNotContains('"main_articles"."published"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Alias cache isolation between queries
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_alias_cache_does_not_bleed_between_queries()
+    {
+        Author::query()->joinRelationship('articles', fn ($join) => $join->as('a'))->toSql();
+
+        $query = Author::query()->joinRelationship('articles')->toSql();
+
+        $this->assertQueryContains(
+            'inner join "sec_articles" on "sec_articles"."author_id" = "main_authors"."id"',
+            $query
+        );
+        $this->assertQueryNotContains(' as "a"', $query);
+        $this->assertQueryNotContains('"a"."author_id"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Extra conditions combined with alias
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_extra_conditions_with_alias_cross_connection()
+    {
+        $query = Author::query()
+            ->joinRelationship('publishedArticles', fn ($join) => $join->as('p'))
+            ->toSql();
+
+        $this->assertQueryContains('"sec_articles" as "p"', $query);
+        $this->assertQueryContains('"p"."author_id" = "main_authors"."id"', $query);
+        $this->assertQueryContains('"p"."published"', $query);
+        $this->assertQueryNotContains('"main_articles"."published"', $query);
+        $this->assertQueryNotContains('"sec_articles"."published"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | joinRelationshipUsingAlias — nested
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_join_relationship_using_alias_nested_across_connections()
+    {
+        $query = Author::query()->joinRelationshipUsingAlias('articles.comments')->toSql();
+
+        $this->assertQueryContains('"sec_articles" as', $query);
+        $this->assertQueryContains('"sec_comments" as', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+        $this->assertQueryNotContains('"main_comments"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Array alias form
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_array_alias_form_on_cross_connection_relationship()
+    {
+        $query = Author::query()
+            ->joinRelationship('articles', [
+                'articles' => fn ($join) => $join->as('art'),
+            ])
+            ->toSql();
+
+        $this->assertQueryContains('"sec_articles" as "art"', $query);
+        $this->assertQueryContains('"art"."author_id" = "main_authors"."id"', $query);
+        $this->assertQueryNotContains('"main_articles"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Regression: same-connection join must not wrap table in Expression
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_same_connection_join_under_cross_connection_suite_still_works()
+    {
+        // Article (sec_) -> comments (sec_) — both on the same connection.
+        $query = Article::query()->joinRelationship('comments')->toSql();
+
+        $this->assertQueryContains('from "sec_articles"', $query);
+        $this->assertQueryContains(
+            'inner join "sec_comments" on "sec_comments"."article_id" = "sec_articles"."id"',
+            $query
+        );
+        $this->assertQueryNotContains('"main_', $query);
+    }
+}

--- a/tests/JoinRelationshipAcrossConnectionsTest.php
+++ b/tests/JoinRelationshipAcrossConnectionsTest.php
@@ -983,4 +983,134 @@ class JoinRelationshipAcrossConnectionsTest extends TestCase
         $this->assertQueryContains('"author_alias"."deleted_at" is null', $query);
         $this->assertQueryNotContains('"primary_db"."authors"."deleted_at"', $query);
     }
+
+    /*
+    |--------------------------------------------------------------------------
+    | whereNull with Expression columns and alias
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_where_null_replaces_alias_in_expression_column_cross_db()
+    {
+        // When disableExtraConditions removes the auto soft-delete clause, and
+        // the user re-adds it manually via whereNull with a cross-db Expression
+        // column, the alias replacement in whereNull must handle Expression columns.
+        $authorModel = new Author();
+        $query = Article::query()
+            ->joinRelationship('author', function ($join) use ($authorModel) {
+                $join->as('a');
+                $join->whereNull(
+                    \Kirschbaum\PowerJoins\ConnectionAwareTable::columnReference(
+                        $authorModel,
+                        Article::query(),
+                        $authorModel->getDeletedAtColumn(),
+                    )
+                );
+            }, disableExtraConditions: true)
+            ->toSql();
+
+        // The whereNull should use the alias 'a', not the original table reference
+        $this->assertQueryContains('"a"."deleted_at" is null', $query);
+        $this->assertQueryNotContains('"primary_db"."authors"."deleted_at"', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | onlyTrashed fallback with cross-database qualification
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_only_trashed_fallback_qualifies_column_for_cross_database()
+    {
+        // When disableExtraConditions: true removes the auto soft-delete clause,
+        // calling onlyTrashed() falls back to getQualifiedDeletedAtColumn() which
+        // returns "authors.deleted_at" without the database qualifier needed for
+        // cross-database joins.
+        $query = Author::query()
+            ->joinRelationship('articles', function ($join) {
+                $join->onlyTrashed();
+            }, disableExtraConditions: true)
+            ->toSql();
+
+        // The fallback must produce the fully-qualified cross-db reference
+        $this->assertQueryContains('"secondary_db"."articles"."deleted_at" is not null', $query);
+        $this->assertQueryNotContains(' "articles"."deleted_at" is not null', $query);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | orderByPowerJoins aggregation with qualified table in selectRaw
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_order_by_power_joins_count_uses_qualified_table_with_prefix()
+    {
+        // When the secondary connection has a table prefix, orderByPowerJoinsCount
+        // uses a raw selectRaw with the plain table name. The selectRaw must use the
+        // same qualified reference as the join.
+        config(['database.connections.secondary' => [
+            'driver' => 'mysql',
+            'database' => 'secondary_db',
+            'prefix' => 'sec_',
+            'foreign_key_constraints' => false,
+        ]]);
+
+        $query = Author::query()->orderByPowerJoinsCount('articles.id')->toSql();
+
+        // The selectRaw must reference the prefixed, DB-qualified table
+        $this->assertQueryContains('"secondary_db"."sec_articles"."id"', $query);
+        // Must NOT use the raw unqualified table name in the aggregation
+        $this->assertQueryNotContains('(articles.id)', $query);
+
+        // Restore config
+        $this->getEnvironmentSetUp(app());
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pivot table with dot-qualified name
+    |--------------------------------------------------------------------------
+    */
+
+    /** @test */
+    public function test_pivot_table_already_qualified_with_dot_is_not_re_qualified()
+    {
+        // When the user manually qualifies the pivot table name with a database
+        // prefix (e.g., "secondary_db.author_tag"), the lib should detect the dot
+        // and treat it as already qualified, not apply its own qualification on top.
+        $query = Author::query()->joinRelationship('tagsOnSecondaryPivot')->toSql();
+
+        // The pivot join should use the user-provided qualified name
+        $this->assertQueryContains('"secondary_db"."author_tag"', $query);
+        // The related table should still use related's connection
+        $this->assertQueryContains('"secondary_db"."tags"', $query);
+    }
+
+    /** @test */
+    public function test_pivot_table_already_qualified_with_prefix_is_not_double_prefixed()
+    {
+        // When secondary connection has a table prefix and the pivot is manually
+        // qualified with the database name, the prefix should NOT be applied on
+        // top of the already-qualified name.
+        config(['database.connections.secondary' => [
+            'driver' => 'mysql',
+            'database' => 'secondary_db',
+            'prefix' => 'sec_',
+            'foreign_key_constraints' => false,
+        ]]);
+
+        $query = Author::query()->joinRelationship('tagsOnSecondaryPivot')->toSql();
+
+        // The pivot should keep the user-qualified name; no extra prefix
+        $this->assertQueryContains('"secondary_db"."author_tag"', $query);
+        // Must NOT apply the primary connection prefix to the pivot
+        $this->assertQueryNotContains('"secondary_db"."pri_author_tag"', $query);
+        $this->assertQueryNotContains('"secondary_db"."sec_author_tag"', $query);
+
+        // Restore config
+        $this->getEnvironmentSetUp(app());
+    }
 }

--- a/tests/Models/CrossConnection/Article.php
+++ b/tests/Models/CrossConnection/Article.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Kirschbaum\PowerJoins\Tests\Models\CrossConnection;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Article extends Model
+{
+    use SoftDeletes;
+
+    protected $connection = 'secondary';
+
+    protected $table = 'articles';
+
+    public $timestamps = false;
+
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(Author::class, 'author_id');
+    }
+
+    public function authorWithTrashed(): BelongsTo
+    {
+        return $this->belongsTo(Author::class, 'author_id')->withTrashed();
+    }
+
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class, 'article_id');
+    }
+
+    public function scopePublished($query)
+    {
+        $query->where('articles.published', true);
+    }
+}

--- a/tests/Models/CrossConnection/Author.php
+++ b/tests/Models/CrossConnection/Author.php
@@ -15,7 +15,7 @@ class Author extends Model
 {
     use SoftDeletes;
 
-    protected $connection = 'testing';
+    protected $connection = 'primary';
 
     protected $table = 'authors';
 

--- a/tests/Models/CrossConnection/Author.php
+++ b/tests/Models/CrossConnection/Author.php
@@ -51,6 +51,11 @@ class Author extends Model
         return $this->belongsToMany(Tag::class, 'author_tag', 'author_id', 'tag_id');
     }
 
+    public function tagsOnSecondaryPivot(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'secondary_db.author_tag', 'author_id', 'tag_id');
+    }
+
     public function stickers(): MorphMany
     {
         return $this->morphMany(Sticker::class, 'stickerable');

--- a/tests/Models/CrossConnection/Author.php
+++ b/tests/Models/CrossConnection/Author.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Kirschbaum\PowerJoins\Tests\Models\CrossConnection;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Author extends Model
+{
+    use SoftDeletes;
+
+    protected $connection = 'testing';
+
+    protected $table = 'authors';
+
+    public $timestamps = false;
+
+    public function articles(): HasMany
+    {
+        return $this->hasMany(Article::class, 'author_id');
+    }
+
+    public function publishedArticles(): HasMany
+    {
+        return $this->hasMany(Article::class, 'author_id')->where('articles.published', true);
+    }
+
+    public function articlesWithTrashed(): HasMany
+    {
+        return $this->hasMany(Article::class, 'author_id')->withTrashed();
+    }
+
+    public function articlesOnlyTrashed(): HasMany
+    {
+        return $this->hasMany(Article::class, 'author_id')->onlyTrashed();
+    }
+
+    public function profile(): HasOne
+    {
+        return $this->hasOne(Profile::class, 'author_id');
+    }
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'author_tag', 'author_id', 'tag_id');
+    }
+
+    public function stickers(): MorphMany
+    {
+        return $this->morphMany(Sticker::class, 'stickerable');
+    }
+
+    public function labels(): MorphToMany
+    {
+        return $this->morphToMany(Label::class, 'labelable', 'labelables', 'labelable_id', 'label_id');
+    }
+
+    public function commentsThroughArticles(): HasManyThrough
+    {
+        return $this->hasManyThrough(Comment::class, Article::class, 'author_id', 'article_id');
+    }
+
+    public function scopeHasPublishedArticles($query)
+    {
+        $query->powerJoinWhereHas('articles', function ($join) {
+            $join->where('articles.published', true);
+        });
+    }
+}

--- a/tests/Models/CrossConnection/Comment.php
+++ b/tests/Models/CrossConnection/Comment.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kirschbaum\PowerJoins\Tests\Models\CrossConnection;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Comment extends Model
+{
+    protected $connection = 'secondary';
+
+    protected $table = 'comments';
+
+    public $timestamps = false;
+
+    public function article(): BelongsTo
+    {
+        return $this->belongsTo(Article::class, 'article_id');
+    }
+}

--- a/tests/Models/CrossConnection/Label.php
+++ b/tests/Models/CrossConnection/Label.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Kirschbaum\PowerJoins\Tests\Models\CrossConnection;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Label extends Model
+{
+    protected $connection = 'secondary';
+
+    protected $table = 'labels';
+
+    public $timestamps = false;
+}

--- a/tests/Models/CrossConnection/Profile.php
+++ b/tests/Models/CrossConnection/Profile.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kirschbaum\PowerJoins\Tests\Models\CrossConnection;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Profile extends Model
+{
+    protected $connection = 'secondary';
+
+    protected $table = 'profiles';
+
+    public $timestamps = false;
+
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(Author::class, 'author_id');
+    }
+}

--- a/tests/Models/CrossConnection/Sticker.php
+++ b/tests/Models/CrossConnection/Sticker.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kirschbaum\PowerJoins\Tests\Models\CrossConnection;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Sticker extends Model
+{
+    protected $connection = 'secondary';
+
+    protected $table = 'stickers';
+
+    public $timestamps = false;
+
+    public function stickerable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/tests/Models/CrossConnection/Tag.php
+++ b/tests/Models/CrossConnection/Tag.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Kirschbaum\PowerJoins\Tests\Models\CrossConnection;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    protected $connection = 'secondary';
+
+    protected $table = 'tags';
+
+    public $timestamps = false;
+}


### PR DESCRIPTION
#34 
---

## 🔗 Cross-Connection Join Support for eloquent-power-joins

### 📖 Overview

Added support for joining Eloquent relationships that live on different database connections. Previously, the package always used the base query's connection prefix for all joined tables, producing incorrect SQL when the related model used a different connection (and thus a different table prefix).

Cross-connection qualification is now automatic and plug-and-play — no manual configuration required. The package detects the driver and applies the correct behaviour:

- **MySQL**: joins across connections are automatically qualified with the database name (`database.table`)
- **SQLite**: cross-connection joins skip qualification entirely (SQLite requires `ATTACH DATABASE` and does not support the simple `database.table` syntax)

---

### 🆕 New File: `src/ConnectionAwareTable.php`

A helper class that centralizes all cross-connection awareness logic:

- `isCrossConnection(Model $owner, $baseQuery)` — detects when the related model's connection differs from the base query's  
- `tableReference(...)` — returns a plain string for same-connection joins (grammar handles prefixing as before), or an `Expression` with the related connection's prefix already baked in for cross-connection joins  
- `columnReference(...)` — same logic for `table.column` references  
- `tableOrAliasReference(...)` / `columnOrAliasReference(...)` — alias-aware variants that check the static alias cache first  
- `rewriteQualifiedColumn(...)` — rewrites a `"table.col"` string to a properly prefixed `Expression`  
- `qualifiedDatabaseName(Model $model): ?string` — returns the database name to use as a qualifier, or `null` when not applicable (SQLite driver or empty database name). Used internally and by `PowerJoinClause`

> ❗ **Removed:** the previous opt-in API (`qualifyWithDatabaseName`, `disableDatabaseQualification`, `shouldQualifyWithDatabase`) has been removed. Qualification is now fully automatic based on the connection driver.

---

### ✏️ Modified: `src/Mixins/JoinRelationship.php`

- Removed the string type hint from `$table` in the `newPowerJoinClause` closure to allow `Expression` objects to be passed  
- Updated `orderByPowerJoins` to use `ConnectionAwareTable::columnReference()` instead of `sprintf('%s.%s', $table, $column)`, so the `ORDER BY` column reference carries the correct prefix for cross-connection joins  

---

### 🛠️ Modified: `src/PowerJoinClause.php`

Multiple fixes to handle `Expression` objects flowing through string-manipulation methods:

- **Constructor** — removed string type hint from `$table`; extracts the plain table name from an `Expression` to populate `$this->tableName`  
- **as() method** — when `$this->table` is an `Expression`, appends the alias to it as a new `Expression`; otherwise uses the original string format  
- **useTableAliasInConditions()** — unwraps `Expression` from `$where['column']` before calling `Str::contains()` on soft-delete checks  
- **useAliasInWhereColumnType()** — unwraps `Expression` from `$where['first']` and `$where['second']` before string replacements  
- **useAliasInWhereBasicType()** — unwraps `Expression` from `$where['column']` before string replacements  
- **whereNull()** — guards `Str::contains()` with `is_string($columns)` to avoid errors when an `Expression` is passed  
- **where()** — cross-connection detection: when no alias is set but the column references the model's own table and the model is on a different connection, rewrites the plain `"table.col"` string into a fully-qualified `Expression` using `ConnectionAwareTable::qualifiedDatabaseName()`  

---

### 🧪 Modified: `tests/JoinRelationshipAcrossConnectionsTest.php`

**54 tests** covering all major scenarios.

The test setup uses two named MySQL-driver connections (`primary` / `secondary`) with:

- Distinct database names (`primary_db` / `secondary_db`)  
- Table prefixes (`pri_` / `sec_`)  

SQLite prefix behaviour is tested via a dedicated `:memory:` sub-case that verifies the database name is never emitted as a qualifier.

### 📊 Test Coverage

| Category                                   | Tests |
|--------------------------------------------|------|
| Basic join types                           | HasMany (inner/left/right), BelongsTo, HasOne — verifies related prefix and absence of wrong prefix |
| Nested relationships                       | HasMany→HasMany, BelongsTo→BelongsTo, zig-zag across connections |
| Polymorphic                                | MorphMany, MorphToMany (morph type qualifier), MorphTo (same/cross-connection morphable) |
| HasManyThrough                             | Through table and far table both use related connection's prefix |
| Soft deletes                               | deleted_at IS NULL uses correct prefix; withTrashed suppresses clause; onlyTrashed emits IS NOT NULL |
| Extra conditions / scopes                  | Relationship-level where() scopes; callback closures on joinRelationship |
| Aliases                                    | Inline as(), joinRelationshipUsingAlias, string alias shorthand, array alias form, nested usingAlias |
| Auto-select                                | SELECT clause uses the base model's own prefix |
| powerJoinHas / powerJoinWhereHas / powerJoinDoesntHave | Basic, nested, count threshold, with and without callback |
| orderByPowerJoins                          | Plain sort, left join sort, three-level nested, all aggregation variants (count, sum, avg, min, max) |
| Connection prefix (SQLite)                 | Prefix is included in table name; `:memory:` database name is never emitted as a qualifier |
| Alias cache isolation                      | Alias from one query does not bleed into the next |
| Mixed same/cross-connection                | Multiple joinRelationship calls with both same- and different-connection relations |
| Multiple cross-connection siblings         | Three unrelated cross-connection joins in one query |
| Duplicate join guard                       | Same cross-connection relationship joined twice produces only one JOIN clause |
| Same-connection regression                 | Joining two models on the same connection does not wrap the table in an Expression |

--- 