### PR TITLE
bugfix: use parent table alias in MorphOneOrMany join

### DIFF
--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -223,7 +223,9 @@ class RelationshipsExtraMethods
     protected function performJoinForEloquentPowerJoinsForMorph()
     {
         return function ($builder, $joinType, $callback = null, $alias = null, bool $disableExtraConditions = false) {
-            $builder->{$joinType}($this->getModel()->getTable(), function ($join) use ($callback, $disableExtraConditions, $alias) {
+            $parentTable = StaticCache::getTableOrAliasForModel($this->parent);
+
+            $builder->{$joinType}($this->getModel()->getTable(), function ($join) use ($callback, $disableExtraConditions, $alias, $parentTable) {
                 if ($alias) {
                     $join->as($alias);
                 }
@@ -231,7 +233,7 @@ class RelationshipsExtraMethods
                 $join->on(
                     "{$this->getModel()->getTable()}.{$this->getForeignKeyName()}",
                     '=',
-                    "{$this->parent->getTable()}.{$this->localKey}"
+                    "{$parentTable}.{$this->localKey}"
                 )->where("{$this->getModel()->getTable()}.{$this->getMorphType()}", '=', $this->getMorphClass());
 
                 if ($disableExtraConditions === false && $this->usesSoftDeletes($this->query->getScopes())) {

--- a/tests/JoinRelationshipUsingAliasTest.php
+++ b/tests/JoinRelationshipUsingAliasTest.php
@@ -382,4 +382,18 @@ class JoinRelationshipUsingAliasTest extends TestCase
             $query
         );
     }
+
+    /**
+     * @test
+     */
+    public function test_morph_join_uses_parent_alias_in_on_condition()
+    {
+        $query = User::joinRelationship('posts.images', [
+            'posts' => fn ($join) => $join->as('posts_alias'),
+        ])->toSql();
+
+        // The ON condition must reference the alias, not the original table name
+        $this->assertQueryContains('imageable_id = posts_alias.id', $query);
+        $this->assertStringNotContainsString('imageable_id = posts.id', $query);
+    }
 }


### PR DESCRIPTION
Hi, I noticed in a morph hasOneThrough relation, the table alias would not be picked up. 

<img width="916" height="113" alt="Screenshot 2026-05-28 at 15 17 02" src="https://github.com/user-attachments/assets/6d1b08d1-f16b-4bdd-8a27-ad4859538756" />



The join is built up like this:

```php
->joinRelation('complainantRelation.user', [
    'complainantRelation' => [
        'complaint_has_relations' => fn($join) => $join->as('chr_complainant'),
        'user_relations' => fn($join) => $join->as('complainant_representative_relations'),
    ],
    'user' => fn($join) => $join->as('complainant_user'),
])
```