### PR TITLE
Fix model not being returned if latestOfMany relationship is soft deleted

### DIFF
--- a/src/Mixins/RelationshipsExtraMethods.php
+++ b/src/Mixins/RelationshipsExtraMethods.php
@@ -302,8 +302,8 @@ class RelationshipsExtraMethods
                 $fkColumn = $this->getOneOfManySubQuery()->getQuery()->columns[1];
                 $localKey = $this->localKey;
 
-                $builder->where(function ($query) use ($column, $joinType, $joinedModel, $builder, $fkColumn, $parentTable, $localKey) {
-                    $query->whereIn($joinedModel->getQualifiedKeyName(), function ($query) use ($column, $joinedModel, $builder, $fkColumn, $parentTable, $localKey) {
+                $builder->where(function ($query) use ($column, $joinType, $joinedModel, $builder, $fkColumn, $parentTable, $localKey, $disableExtraConditions) {
+                    $query->whereIn($joinedModel->getQualifiedKeyName(), function ($query) use ($column, $joinedModel, $builder, $fkColumn, $parentTable, $localKey, $disableExtraConditions) {
                         $columnValue = $column->getValue($builder->getGrammar());
                         $direction = Str::contains($columnValue, 'min(') ? 'asc' : 'desc';
 
@@ -311,13 +311,17 @@ class RelationshipsExtraMethods
                         $columnName = Str::replace(['"', "'", '`'], '', $columnName);
 
                         if ($builder->getConnection() instanceof MySqlConnection) {
-                            $query->select('*')->from(function ($query) use ($joinedModel, $columnName, $fkColumn, $direction, $parentTable, $localKey) {
+                            $query->select('*')->from(function ($query) use ($joinedModel, $columnName, $fkColumn, $direction, $parentTable, $localKey, $disableExtraConditions) {
                                 $query
                                     ->select($joinedModel->getQualifiedKeyName())
                                     ->from($joinedModel->getTable())
                                     ->whereColumn($fkColumn, "{$parentTable}.{$localKey}")
                                     ->orderBy($columnName, $direction)
                                     ->take(1);
+
+                                if ($disableExtraConditions === false && $this->usesSoftDeletes($this->query->getScopes())) {
+                                    $query->whereNull($this->query->getModel()->getDeletedAtColumn());
+                                }
                             });
                         } else {
                             $query
@@ -327,6 +331,10 @@ class RelationshipsExtraMethods
                                 ->whereColumn($fkColumn, "{$parentTable}.{$localKey}")
                                 ->orderBy($columnName, $direction)
                                 ->take(1);
+
+                            if ($disableExtraConditions === false && $this->usesSoftDeletes($this->query->getScopes())) {
+                                $query->whereNull($this->query->getModel()->getDeletedAtColumn());
+                            }
                         }
                     });
 

--- a/tests/Models/Address.php
+++ b/tests/Models/Address.php
@@ -37,8 +37,6 @@ class Address extends Model
      */
     public function latest_requested_address(): HasOne
     {
-        return $this->requested_addresses()
-            ->one()
-            ->latestOfMany('requested_at');
+        return $this->requested_addresses()->one()->latestOfMany('requested_at');
     }
 }

--- a/tests/Models/RequestedAddress.php
+++ b/tests/Models/RequestedAddress.php
@@ -4,9 +4,12 @@ namespace Kirschbaum\PowerJoins\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class RequestedAddress extends Model
 {
+    use SoftDeletes;
+
     protected $table = 'requested_addresses';
 
     protected $fillable = [

--- a/tests/OrderByTest.php
+++ b/tests/OrderByTest.php
@@ -4,8 +4,10 @@ namespace Kirschbaum\PowerJoins\Tests;
 
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Support\Facades\DB;
+use Kirschbaum\PowerJoins\Tests\Models\Address;
 use Kirschbaum\PowerJoins\Tests\Models\Comment;
 use Kirschbaum\PowerJoins\Tests\Models\Post;
+use Kirschbaum\PowerJoins\Tests\Models\RequestedAddress;
 use Kirschbaum\PowerJoins\Tests\Models\User;
 use Kirschbaum\PowerJoins\Tests\Models\UserProfile;
 
@@ -231,5 +233,24 @@ class OrderByTest extends TestCase
         $query->get();
 
         $this->assertTrue(true, 'No exceptions, we are good :)');
+    }
+
+    public function test_order_by_has_one_of_many_with_soft_delete()
+    {
+        $address1 = factory(Address::class)->create();
+        $requestedAt = now();
+        factory(RequestedAddress::class)->create(['kvh_code' => $address1->kvh_code, 'requested_at' => now()])->delete();
+        factory(RequestedAddress::class)->create(['kvh_code' => $address1->kvh_code, 'requested_at' => now()->addSeconds()]);
+
+        $address2 = factory(Address::class)->create();
+        factory(RequestedAddress::class)->create(['kvh_code' => $address2->kvh_code, 'requested_at' => now()->addSeconds(2)]);
+        factory(RequestedAddress::class)->create(['kvh_code' => $address2->kvh_code, 'requested_at' => now()->addSeconds(3)])->delete();
+
+        $addressesOrderedByLatestRequested = Address::orderByPowerJoins('latest_requested_address.created_at', 'desc')->get();
+
+        $this->assertCount(2, $addressesOrderedByLatestRequested);
+
+        // making sure left join do not throw exceptions
+        Address::orderByLeftPowerJoins('latest_requested_address.created_at', 'desc')->get();
     }
 }

--- a/tests/database/factories/AddressFactory.php
+++ b/tests/database/factories/AddressFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+use Kirschbaum\PowerJoins\Tests\Models\Address;
+
+$factory->define(Address::class, function (Faker\Generator $faker) {
+    return [
+        'kvh_code' => $faker->unique()->bothify('???###'),
+        'name' => $faker->streetName,
+        'city_id' => null,
+    ];
+});

--- a/tests/database/factories/RequestedAddressFactory.php
+++ b/tests/database/factories/RequestedAddressFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+use Kirschbaum\PowerJoins\Tests\Models\RequestedAddress;
+
+$factory->define(RequestedAddress::class, function (Faker\Generator $faker) {
+    return [
+        'kvh_code' => $faker->unique()->bothify('???###'),
+        'requested_at' => $faker->dateTimeBetween('-1 year', 'now'),
+        'status' => 'pending',
+    ];
+});

--- a/tests/database/migrations/2020_03_16_000000_create_tables.php
+++ b/tests/database/migrations/2020_03_16_000000_create_tables.php
@@ -127,6 +127,7 @@ class CreateTables extends Migration
             $table->timestamp('requested_at');
             $table->string('status')->default('pending');
             $table->timestamps();
+            $table->softDeletes();
 
             $table->index('kvh_code');
         });


### PR DESCRIPTION
# Original issue
When sorting entities by a column of another Model with soft deletes and related by `latestOfMany`, the ones for which the latest entry of the relationship was deleted where not returned in the query result. The subquery generated for the HasOne type of relation ignore the `SoftDeletingScope`* and return the id of a soft deleted entity, and that id end up matching with no entries from the outer query's join that does apply the `SoftDeletingScope`*.

*_Or to be more precise, its equivalent condition with the base Query\Builder_

# Summary
Filter out soft deleted entries in subquery when sorting by `latestOfMany` relationship if related model uses soft delete.

# Linting
- [x] ran command `vendor/bin/php-cs-fixer fix` before pushing

# Test plan
- [x] full test suite passes - ~~_waiting for the CI to run with all appropriate databases. Locally I had the same results (error/skipped) before and after the code change._~~
- [x] Verify that `orderByPowerJoins` correctly return entity when at least one related entity isn't soft deleted (wether the soft deleted one is the "latest" or not) - covered by `test_order_by_has_one_of_many_with_soft_delete`