### PR TITLE
Fix Laravel CI dependency matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+env:
+    # Laravel 11 remains supported by this package but no longer has patched releases.
+    COMPOSER_POLICY_ADVISORIES_BLOCK: '0'
+
 jobs:
     mysql_8:
         runs-on: ubuntu-24.04
@@ -54,7 +58,10 @@ jobs:
                 with:
                     timeout_minutes: 5
                     max_attempts: 5
-                    command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+                    command: |
+                        composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+                        composer require "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
+                        composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
             -   name: Execute tests
                 run: vendor/bin/phpunit
@@ -118,8 +125,7 @@ jobs:
                     composer --version
                     composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
                     composer require "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
-                    composer update --prefer-dist --no-interaction --no-suggest --dev
-                    composer dump
+                    composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
             -   name: Execute tests
                 run: vendor/bin/phpunit
@@ -174,8 +180,7 @@ jobs:
                     composer --version
                     composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
                     composer require "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
-                    composer update --prefer-dist --no-interaction --no-suggest --dev
-                    composer dump
+                    composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
             -   name: Setup SQLite Database
                 run: php vendor/bin/testbench package:create-sqlite-db


### PR DESCRIPTION
## Summary

- allow compatibility jobs to resolve Laravel 11 under Composer 2.10 while preserving other dependency policies
- make MySQL jobs install the Laravel and Testbench versions named by the matrix
- remove deprecated Composer update flags from PostgreSQL and SQLite jobs

## Why

Composer 2.10 blocks all Laravel 11 releases because no advisory-free release exists. This package still supports Laravel 11, so compatibility tests need to disable advisory blocking explicitly. The existing MySQL matrix also did not apply its Laravel or Testbench values, which made Laravel 11-labeled jobs test newer framework versions.

## Verification

- Laravel 11 dependency resolution succeeds with `COMPOSER_POLICY_ADVISORIES_BLOCK=0`
- full test suite passes locally on Laravel 11
- workflow parses as valid YAML
- PHP-CS-Fixer dry run passes